### PR TITLE
Release v2.5.1

### DIFF
--- a/docs/CONFIG_DIFF.md
+++ b/docs/CONFIG_DIFF.md
@@ -1,6 +1,6 @@
 # Config Diff
 
-Package version: `2.5.0`
+Package version: `2.5.1`
 Expo config version: `56.0.4`
 
 ## Rule Counts
@@ -525,6 +525,7 @@ Expo config version: `56.0.4`
 - `import/no-unresolved`
 - `no-unused-vars`
 - `react-hooks/exhaustive-deps`
+- `react-hooks/set-state-in-effect`
 - `react/jsx-key`
 
 ### Removed

--- a/docs/config-diff.json
+++ b/docs/config-diff.json
@@ -1,5 +1,5 @@
 {
-  "packageVersion": "2.5.0",
+  "packageVersion": "2.5.1",
   "expoConfigVersion": "56.0.4",
   "presets": {
     "expo": {
@@ -751,7 +751,7 @@
         "react-hooks/purity": "error",
         "react-hooks/refs": "error",
         "react-hooks/rules-of-hooks": "error",
-        "react-hooks/set-state-in-effect": "error",
+        "react-hooks/set-state-in-effect": "off",
         "react-hooks/set-state-in-render": "error",
         "react-hooks/static-components": "error",
         "react-hooks/unsupported-syntax": "warn",
@@ -1128,7 +1128,7 @@
         "react-hooks/purity": "error",
         "react-hooks/refs": "error",
         "react-hooks/rules-of-hooks": "error",
-        "react-hooks/set-state-in-effect": "error",
+        "react-hooks/set-state-in-effect": "off",
         "react-hooks/set-state-in-render": "error",
         "react-hooks/static-components": "error",
         "react-hooks/unsupported-syntax": "warn",
@@ -1731,7 +1731,7 @@
         "react-hooks/purity": "error",
         "react-hooks/refs": "error",
         "react-hooks/rules-of-hooks": "error",
-        "react-hooks/set-state-in-effect": "error",
+        "react-hooks/set-state-in-effect": "off",
         "react-hooks/set-state-in-render": "error",
         "react-hooks/static-components": "error",
         "react-hooks/unsupported-syntax": "warn",
@@ -2385,7 +2385,7 @@
         "react-hooks/purity": "error",
         "react-hooks/refs": "error",
         "react-hooks/rules-of-hooks": "error",
-        "react-hooks/set-state-in-effect": "error",
+        "react-hooks/set-state-in-effect": "off",
         "react-hooks/set-state-in-render": "error",
         "react-hooks/static-components": "error",
         "react-hooks/unsupported-syntax": "warn",
@@ -3820,7 +3820,7 @@
         "react-hooks/purity": "error",
         "react-hooks/refs": "error",
         "react-hooks/rules-of-hooks": "error",
-        "react-hooks/set-state-in-effect": "error",
+        "react-hooks/set-state-in-effect": "off",
         "react-hooks/set-state-in-render": "error",
         "react-hooks/static-components": "error",
         "react-hooks/unsupported-syntax": "warn",
@@ -4453,6 +4453,7 @@
         "import/no-unresolved",
         "no-unused-vars",
         "react-hooks/exhaustive-deps",
+        "react-hooks/set-state-in-effect",
         "react/jsx-key"
       ]
     },

--- a/packages/eslint-config-expo-magic/index.test.ts
+++ b/packages/eslint-config-expo-magic/index.test.ts
@@ -331,6 +331,15 @@ describe('eslint-config-expo-magic', () => {
 			expect(hasRule).toBe(true);
 		});
 
+		it('keeps synchronous effect state updates opt-in', () => {
+			const hooksConfig = config.find(
+				(c: FlatConfig) =>
+					c.rules && c.rules['react-hooks/set-state-in-effect'],
+			);
+			expect(hooksConfig).toBeDefined();
+			expect(hooksConfig.rules['react-hooks/set-state-in-effect']).toBe('off');
+		});
+
 		it('enables react-native rules', () => {
 			const rnConfig = config.find(
 				(c: FlatConfig) =>

--- a/packages/eslint-config-expo-magic/package.json
+++ b/packages/eslint-config-expo-magic/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "eslint-config-expo-magic",
-	"version": "2.5.0",
+	"version": "2.5.1",
 	"description": "ESLint flat config for Expo, React Native, and TypeScript projects",
 	"keywords": [
 		"eslint",

--- a/packages/eslint-config-expo-magic/utils/react.js
+++ b/packages/eslint-config-expo-magic/utils/react.js
@@ -44,6 +44,7 @@ module.exports = [
 		rules: {
 			...pluginReactHooks.configs.flat.recommended.rules,
 			'react-hooks/exhaustive-deps': 'error',
+			'react-hooks/set-state-in-effect': 'off',
 			'react/jsx-no-leaked-render': 'error',
 			'react/jsx-no-useless-fragment': 'error',
 			'react/jsx-key': 'error',


### PR DESCRIPTION
# Summary
Release v2.5.1 with a less disruptive React Hooks default for existing Expo apps.

# Changes
- Set react-hooks/set-state-in-effect to off by default while keeping exhaustive-deps strict
- Add regression coverage for the rule default
- Update package version and config diff artifacts