### PR TITLE
Fix release workflow npm auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,4 +115,6 @@ jobs:
 
       - name: Publish npm package
         if: steps.release.outputs.should_publish == 'true'
+        env:
+          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: bun scripts/publish-package.js --publish


### PR DESCRIPTION
# Summary
Fixes npm authentication for the release workflow publish step.

# Changes
- Pass the NPM_TOKEN secret to Bun publish through NPM_CONFIG_TOKEN