### PR TITLE
Publish releases with npm CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,11 @@ jobs:
             exit 1
           fi
 
-          printf "//registry.npmjs.org/:_authToken=%s\n" "${NPM_TOKEN}" > "${HOME}/.npmrc"
+          package_npmrc="${GITHUB_WORKSPACE}/packages/eslint-config-expo-magic/.npmrc"
+
+          printf "registry=https://registry.npmjs.org/\n//registry.npmjs.org/:_authToken=%s\n" "${NPM_TOKEN}" > "${HOME}/.npmrc"
+          printf "registry=https://registry.npmjs.org/\n//registry.npmjs.org/:_authToken=%s\n" "${NPM_TOKEN}" > "${package_npmrc}"
+          chmod 0600 "${HOME}/.npmrc" "${package_npmrc}"
 
       - name: Publish npm package
         if: steps.release.outputs.should_publish == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 concurrency:
   group: release-main
@@ -28,6 +29,12 @@ jobs:
         with:
           bun-version: 1.3.11
 
+      - uses: actions/setup-node@v6.4.0
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
       - name: Check release version
         id: release
         env:
@@ -38,7 +45,7 @@ jobs:
           version="$(node -p "require('./packages/eslint-config-expo-magic/package.json').version")"
           tag="v${version}"
           latest_tag="$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name 2>/dev/null || true)"
-          published_version="$(bun pm view "eslint-config-expo-magic@${version}" version 2>/dev/null | tr -d '"' || true)"
+          published_version="$(npm view "eslint-config-expo-magic@${version}" version --json 2>/dev/null | tr -d '"' || true)"
 
           should_create=true
           create_reason=
@@ -99,26 +106,8 @@ jobs:
             --title "${RELEASE_TAG}" \
             --notes-file docs/RELEASE_NOTES.next.md
 
-      - name: Configure npm auth
-        if: steps.release.outputs.should_publish == 'true'
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          set -euo pipefail
-
-          if [ -z "${NPM_TOKEN}" ]; then
-            echo "NPM_TOKEN secret is required to publish to npm."
-            exit 1
-          fi
-
-          package_npmrc="${GITHUB_WORKSPACE}/packages/eslint-config-expo-magic/.npmrc"
-
-          printf "registry=https://registry.npmjs.org/\n//registry.npmjs.org/:_authToken=%s\n" "${NPM_TOKEN}" > "${HOME}/.npmrc"
-          printf "registry=https://registry.npmjs.org/\n//registry.npmjs.org/:_authToken=%s\n" "${NPM_TOKEN}" > "${package_npmrc}"
-          chmod 0600 "${HOME}/.npmrc" "${package_npmrc}"
-
       - name: Publish npm package
         if: steps.release.outputs.should_publish == 'true'
         env:
-          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: bun scripts/publish-package.js --publish

--- a/docs/CONFIG_DIFF.md
+++ b/docs/CONFIG_DIFF.md
@@ -1,6 +1,6 @@
 # Config Diff
 
-Package version: `2.5.1`
+Package version: `2.5.2`
 Expo config version: `56.0.4`
 
 ## Rule Counts

--- a/docs/RELEASE_NOTES.next.md
+++ b/docs/RELEASE_NOTES.next.md
@@ -1,13 +1,13 @@
 # Changes
 
-- Package version: `2.5.0`
+- Package version: `2.5.2`
 - Expo base version: `56.0.4`
 - Base preset vs Expo: 1 rule added, 0 rules changed, 40 rules removed.
   - Added: `expo/prefer-box-shadow`
   - Removed: `react-hooks/component-hook-factories`, `react-hooks/config`, `react-hooks/error-boundaries`, `react-hooks/exhaustive-deps`, `react-hooks/gating`, `react-hooks/globals`, `react-hooks/immutability`, `react-hooks/incompatible-library`, and 32 more
-- Default preset vs Expo: 432 rules added, 13 rules changed, 0 rules removed.
+- Default preset vs Expo: 432 rules added, 14 rules changed, 0 rules removed.
   - Added: `@babel/object-curly-spacing`, `@babel/semi`, `@stylistic/array-bracket-newline`, `@stylistic/array-bracket-spacing`, `@stylistic/array-element-newline`, `@stylistic/arrow-parens`, `@stylistic/arrow-spacing`, `@stylistic/block-spacing`, and 424 more
-  - Changed: `@typescript-eslint/array-type`, `@typescript-eslint/consistent-type-assertions`, `@typescript-eslint/no-unused-vars`, `import/export`, `import/first`, `import/namespace`, `import/no-duplicates`, `import/no-named-as-default`, and 5 more
+  - Changed: `@typescript-eslint/array-type`, `@typescript-eslint/consistent-type-assertions`, `@typescript-eslint/no-unused-vars`, `import/export`, `import/first`, `import/namespace`, `import/no-duplicates`, `import/no-named-as-default`, and 6 more
 - no-prettier preset delta: `@babel/object-curly-spacing`, `@babel/semi`, `@stylistic/array-bracket-newline`, `@stylistic/array-bracket-spacing`, `@stylistic/array-element-newline`, `@stylistic/arrow-parens`, `@stylistic/arrow-spacing`, `@stylistic/block-spacing`, and 351 more
 - typed preset delta: `@typescript-eslint/adjacent-overload-signatures`, `@typescript-eslint/array-type`, `@typescript-eslint/ban-ts-comment`, `@typescript-eslint/ban-tslint-comment`, `@typescript-eslint/class-literal-property-style`, `@typescript-eslint/consistent-generic-constructors`, `@typescript-eslint/consistent-indexed-object-style`, `@typescript-eslint/consistent-type-assertions`, and 78 more
 - strict preset delta: `@typescript-eslint/no-misused-promises`, `@typescript-eslint/no-non-null-assertion`

--- a/docs/config-diff.json
+++ b/docs/config-diff.json
@@ -1,5 +1,5 @@
 {
-  "packageVersion": "2.5.1",
+  "packageVersion": "2.5.2",
   "expoConfigVersion": "56.0.4",
   "presets": {
     "expo": {

--- a/packages/eslint-config-expo-magic/package.json
+++ b/packages/eslint-config-expo-magic/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "eslint-config-expo-magic",
-	"version": "2.5.1",
+	"version": "2.5.2",
 	"description": "ESLint flat config for Expo, React Native, and TypeScript projects",
 	"keywords": [
 		"eslint",
@@ -102,7 +102,7 @@
 		"./package.json": "./package.json"
 	},
 	"bin": {
-		"expo-magic-pr-guardrails": "./bin/pr-guardrails.js"
+		"expo-magic-pr-guardrails": "bin/pr-guardrails.js"
 	},
 	"sideEffects": false,
 	"files": [

--- a/scripts/publish-package.js
+++ b/scripts/publish-package.js
@@ -72,18 +72,33 @@ function ensureRequiredFiles() {
 	}
 }
 
+function runReleaseCheck() {
+	console.log('\nRunning release checks...');
+	run('node', [path.join(ROOT_DIR, 'scripts', 'release-check.js')], {
+		cwd: ROOT_DIR,
+	});
+}
+
 function main() {
 	const args = process.argv.slice(2);
 	const shouldPublish = args.includes('--publish');
 	const publishArgs = args.filter((arg) => arg !== '--publish');
 
 	ensureRequiredFiles();
+	runReleaseCheck();
 
 	console.log('\nRunning tarball dry-run...');
 	run('bun', ['pm', 'pack', '--dry-run']);
 
 	console.log('\nRunning registry dry-run...');
-	run('bun', ['publish', '--dry-run', ...publishArgs]);
+	run('npm', [
+		'publish',
+		'--dry-run',
+		'--ignore-scripts',
+		'--access',
+		'public',
+		...publishArgs,
+	]);
 
 	if (!shouldPublish) {
 		console.log(
@@ -93,7 +108,14 @@ function main() {
 	}
 
 	console.log('\nPublishing package...');
-	run('bun', ['publish', ...publishArgs]);
+	run('npm', [
+		'publish',
+		'--ignore-scripts',
+		'--access',
+		'public',
+		...(process.env.GITHUB_ACTIONS === 'true' ? ['--provenance'] : []),
+		...publishArgs,
+	]);
 	console.log('\nPublish completed.');
 }
 

--- a/scripts/smoke-packed-consumer.js
+++ b/scripts/smoke-packed-consumer.js
@@ -109,6 +109,15 @@ function listTarballs() {
 		});
 }
 
+function snapshotTarballs() {
+	return new Map(
+		listTarballs().map((file) => [
+			file,
+			fs.statSync(path.join(packageDir, file)).mtimeMs,
+		]),
+	);
+}
+
 function createFixturePackageJson(tarballPath, lane) {
 	return {
 		name: `eslint-config-expo-magic-smoke-${lane.name}`,
@@ -495,7 +504,7 @@ function main() {
 		: process.argv.includes('--preview')
 			? previewSmokeLanes
 			: smokeLanes;
-	const tarballsBefore = new Set(listTarballs());
+	const tarballsBefore = snapshotTarballs();
 	let generatedTarballPath;
 	const tempProjectDirs = [];
 
@@ -503,7 +512,14 @@ function main() {
 		console.log('Packing local tarball...');
 		run('bun', ['pm', 'pack'], { cwd: packageDir });
 
-		const newTarball = listTarballs().find((file) => !tarballsBefore.has(file));
+		const newTarball = listTarballs().find((file) => {
+			const previousMtimeMs = tarballsBefore.get(file);
+			if (previousMtimeMs === undefined) {
+				return true;
+			}
+
+			return fs.statSync(path.join(packageDir, file)).mtimeMs > previousMtimeMs;
+		});
 		if (!newTarball) {
 			throw new Error('Could not find generated tarball from bun pm pack.');
 		}


### PR DESCRIPTION
# Summary
Switches the release workflow to the npm CLI publish path and prepares a clean 2.5.2 release.

# Changes
- Use actions/setup-node with npm registry auth and id-token permissions for release publishes
- Run release checks explicitly before npm dry-run and npm publish
- Bump eslint-config-expo-magic to 2.5.2 and normalize the bin manifest entry
- Make packed-consumer smoke checks handle regenerated tarball filenames