### PR TITLE
Use trusted publishing for npm release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,4 @@ jobs:
 
       - name: Publish npm package
         if: steps.release.outputs.should_publish == 'true'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: bun scripts/publish-package.js --publish


### PR DESCRIPTION
# Summary
Switches the release publish step to npm trusted publishing now that the package has an OIDC publisher configured.

# Changes
- Remove the long-lived npm token environment from the release publish step
- Keep the npm CLI publish path on the existing GitHub Actions OIDC permission