### PR TITLE
v2.7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Install dependencies
         run: bun run ci
 
+      - name: Typecheck public types
+        run: bun run typecheck
+
       - name: Run unit tests
         run: bun run test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable, consumer-facing changes to `eslint-config-expo-magic` are documented here. This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Releases prior to `2.7.0` are recorded in the [GitHub releases](https://github.com/JoaoPauloCMarra/eslint-config-expo-magic/releases).
+
+## 2.7.0
+
+Adds opt-in hardening layers distilled from production Expo/React Native usage. The `default`, `strict`, `typed`, and `no-prettier` presets are unchanged, so upgrading is backward compatible unless you opt into the new layers.
+
+### Added
+
+- **`reanimated` layer** (`createConfig({ reanimated: true })` / `eslint-config-expo-magic/reanimated`) — flags reading shared values in `useSharedValue(...)` initializers, `.get()` inside `useAnimatedStyle`/`useAnimatedReaction`/`useDerivedValue`/`useAnimatedProps` worklet hooks, and inline gesture config passed to RNGH gesture hooks. Configure gesture hook names with `gestureHooks` / `additionalGestureHooks`.
+- **`deprecatedApis` layer** (`createConfig({ deprecatedApis: true })` / `eslint-config-expo-magic/deprecated-apis`) — flags `MutableRefObject` (removed from React 19 typings), `StyleSheet.absoluteFillObject`, and `AccessibilityInfo.setAccessibilityFocus`, with their modern replacements.
+- **`componentStructure` layer** (`createConfig({ componentStructure: true })` / `eslint-config-expo-magic/component-structure`) — a bundled `expo-magic` plugin with four rules: `props-type-order`, `default-export-placement`, `no-inline-props`, and `require-children-usage`. Configure the prop-type matcher with `propsTypePattern`.
+- **`semanticColors` layer** (`createConfig({ semanticColors: true })` / `eslint-config-expo-magic/semantic-colors`) — flags raw color literals (`#rrggbb`, `rgba()`, `hsla()`) and direct color-token access. Configure `tokenModule`, `importName`, `flagDirectAccess`, and `allowFiles`.
+- **`inlineStyles` option** (`createConfig({ inlineStyles: true })`) — enables `react-native/no-inline-styles` (`warn` by default; accepts any severity).
+- **Configurable `appGuardrails`** — `createConfig({ appGuardrails: { queryHookPattern } })` to match your own query-hook naming.
+- **Config factories** — `createAppGuardrailsConfig`, `createComponentStructureConfig`, `createDeprecatedApiConfig`, `createReanimatedConfig`, and `createSemanticColorsConfig` for manual composition.
+- **Exported TypeScript types** — `CreateConfigOptions` and every layer's option type are now importable, giving editors and AI tooling accurate autocomplete and misuse detection.
+
+### Changed
+
+- **`reactCompiler` layer** now promotes the React Compiler diagnostics shipped in `eslint-plugin-react-hooks` v7 (`unsupported-syntax`, `incompatible-library`, `immutability`, `purity`, `preserve-manual-memoization`, `set-state-in-render`, `static-components`) to `error`. This replaces the previous `no-restricted-syntax` heuristics, which falsely flagged optional chaining and `throw` inside any `try` block. The `eslint-config-expo-magic/react-compiler` subpath now exposes `rules` instead of `restrictedSyntaxGroups`.
+- Selector-based hardening layers (`appGuardrails`, `reanimated`, `worklets`, `semanticColors`) are merged into a single `no-restricted-syntax` configuration per file group, so enabling several layers together no longer overrides one another.
+
+### Compatibility
+
+- Expo SDK 54 / 55 / 56, React Native 0.85, React 19.1–19.2, ESLint 10, TypeScript `>=5.9.3 <7`.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Production-focused ESLint flat config for Expo and React Native projects, with T
 - [Customization Patterns](#customization-patterns)
 - [Monorepo Usage](#monorepo-usage)
 - [Troubleshooting](#troubleshooting)
+- [Changelog](#changelog)
 - [Contributing](#contributing)
 
 ## Compatibility
@@ -113,9 +114,13 @@ This package exposes:
 - `eslint-config-expo-magic/strict` -> strict config array
 - `eslint-config-expo-magic/no-prettier` -> base config array without Prettier plugin/rules
 - `eslint-config-expo-magic/typed` -> base config array plus type-aware TypeScript rules
-- `eslint-config-expo-magic/app-guardrails` -> app hygiene layer for suppressions, assertions, query-hook return types, and snapshots
-- `eslint-config-expo-magic/react-compiler` -> React Compiler syntax hardening layer
+- `eslint-config-expo-magic/app-guardrails` -> app hygiene layer for suppressions, assertions, query-hook return types, and snapshots (factory accepts a custom `queryHookPattern`)
+- `eslint-config-expo-magic/react-compiler` -> promotes the React Compiler diagnostics shipped by `eslint-plugin-react-hooks` v7 (`unsupported-syntax`, `purity`, `immutability`, …) to `error`
+- `eslint-config-expo-magic/reanimated` -> Reanimated/RNGH hardening (shared-value render reads, worklet-hook `.get()`, inline gesture config; factory accepts custom gesture hook names)
 - `eslint-config-expo-magic/worklets` -> Worklets `scheduleOnRN` hardening layer
+- `eslint-config-expo-magic/deprecated-apis` -> flags deprecated React Native / React 19 symbols (`MutableRefObject`, `StyleSheet.absoluteFillObject`, `AccessibilityInfo.setAccessibilityFocus`)
+- `eslint-config-expo-magic/component-structure` -> custom `expo-magic` plugin rules for prop-type ordering, default-export placement, inline props, and unused child slots
+- `eslint-config-expo-magic/semantic-colors` -> factory enforcing semantic color tokens over raw color literals/direct token access
 - `eslint-config-expo-magic/native-ui` -> factory for React Native primitive import restrictions
 - `eslint-config-expo-magic/feature-boundaries` -> factory for feature/app/service/UIKit dependency boundaries
 - `eslint-config-expo-magic/storybook` -> story-file overrides
@@ -192,7 +197,11 @@ The package ships declaration files:
 - `typed.d.ts`
 - `app-guardrails.d.ts`
 - `react-compiler.d.ts`
+- `reanimated.d.ts`
 - `worklets.d.ts`
+- `deprecated-apis.d.ts`
+- `component-structure.d.ts`
+- `semantic-colors.d.ts`
 - `native-ui.d.ts`
 - `feature-boundaries.d.ts`
 - `storybook.d.ts`
@@ -246,6 +255,13 @@ Import resolution is configured for monorepos and app/package layouts:
 
 `import-x` is treated as the source of truth. Overlapping legacy `import/*` diagnostics are disabled to avoid duplicate noise.
 
+### Restricted Rule Composition
+
+`no-restricted-imports` and `no-restricted-syntax` are single-slot ESLint rules: the last matching config entry replaces the rule entirely rather than merging. To avoid clobbering:
+
+- All selector-based hardening (`appGuardrails`, `reactCompiler` precursors, `reanimated`, `worklets`, `semanticColors`) is merged into one composed `no-restricted-syntax` config per file group, so enabling several layers together preserves every selector.
+- The base `SafeAreaView` import restriction is shared from one source between the default app rules and `nativeUi`. Replacing `nativeUi` restrictions intentionally drops the base set; pass them back via `restrictions` or use `additionalRestrictions` to extend instead.
+
 ## Customization Patterns
 
 Append your own override object after the preset:
@@ -288,9 +304,11 @@ module.exports = [
 | Same as base, with stricter TypeScript and `no-console: error`  | `eslint-config-expo-magic/strict`      |
 | Same as base, with type-aware TypeScript rules                  | `eslint-config-expo-magic/typed`       |
 | Use a separate formatter pipeline (no `prettier/prettier` rule) | `eslint-config-expo-magic/no-prettier` |
-| Harden production app flows with React Compiler/Worklets/UI rules | `createConfig({ appGuardrails: true, reactCompiler: true, worklets: true })` |
+| Harden production app flows (React Compiler, Reanimated, deprecated APIs, structure) | `createConfig({ appGuardrails: true, reactCompiler: true, reanimated: true, deprecatedApis: true, componentStructure: true })` |
 
 ### Production App Hardening
+
+All hardening layers are opt-in; the default/strict/typed presets are unchanged. Enable any combination:
 
 ```js
 const { createConfig } = require('eslint-config-expo-magic');
@@ -298,7 +316,12 @@ const { createConfig } = require('eslint-config-expo-magic');
 module.exports = createConfig({
 	extraIgnores: ['.eas/**', '.github/**', '.vscode/**', 'assets/**'],
 	appGuardrails: true,
+	componentStructure: true,
+	deprecatedApis: true,
+	inlineStyles: true,
 	reactCompiler: true,
+	reanimated: true,
+	semanticColors: true,
 	worklets: true,
 	storybook: true,
 	nativeUi: {
@@ -318,14 +341,26 @@ module.exports = createConfig({
 });
 ```
 
+Each hardening option also accepts configuration for project-specific conventions:
+
+```js
+module.exports = createConfig({
+	appGuardrails: { queryHookPattern: '^useFetch[A-Z]' },
+	reanimated: { additionalGestureHooks: ['useFlingGesture'] },
+	semanticColors: { tokenModule: 'theme/palette', importName: 'palette' },
+	componentStructure: { propsTypePattern: 'Props$' },
+});
+```
+
 The optional layers are available as subpaths when manual composition is clearer:
 
 ```js
 const expoMagic = require('eslint-config-expo-magic');
 const reactCompiler = require('eslint-config-expo-magic/react-compiler');
-const worklets = require('eslint-config-expo-magic/worklets');
+const reanimated = require('eslint-config-expo-magic/reanimated');
+const deprecatedApis = require('eslint-config-expo-magic/deprecated-apis');
 
-module.exports = [...expoMagic, ...reactCompiler, ...worklets];
+module.exports = [...expoMagic, ...reactCompiler, ...reanimated, ...deprecatedApis];
 ```
 
 ## Monorepo Usage
@@ -360,9 +395,14 @@ This package disables overlapping legacy `import/*` rules. If you still see dupl
 
 Make sure you are using ESLint 10+ and an `eslint.config.js` or `eslint.config.mjs` file (not legacy `.eslintrc*`).
 
+## Changelog
+
+Consumer-facing changes are documented in [`CHANGELOG.md`](./CHANGELOG.md). Per-release notes are also published on the [GitHub releases page](https://github.com/JoaoPauloCMarra/eslint-config-expo-magic/releases).
+
 ## Contributing
 
 - Rule rationale: [`RULES.md`](./RULES.md)
+- Changelog: [`CHANGELOG.md`](./CHANGELOG.md)
 - Main config entry: [`packages/eslint-config-expo-magic/index.js`](./packages/eslint-config-expo-magic/index.js)
 - Validation harness: [`test-project/validate-comprehensive.js`](./test-project/validate-comprehensive.js)
 
@@ -371,6 +411,7 @@ Run locally:
 ```bash
 bun install
 bun run test
+bun run typecheck
 bun run validate
 bun run smoke:pack
 ```

--- a/RULES.md
+++ b/RULES.md
@@ -98,7 +98,46 @@ This document explains the reasoning behind the opinionated rules enforced by `e
 - **`react-hooks/set-state-in-render`**: Prevents calling setState during render (causes infinite loops).
 - **`react-hooks/preserve-manual-memoization`**: Ensures manual memoization doesn't conflict with compiler optimizations.
 
-**Rationale**: These rules work with React Compiler to catch performance issues and ensure components can be safely optimized.
+**Rationale**: These rules work with React Compiler to catch performance issues and ensure components can be safely optimized. The default preset spreads `eslint-plugin-react-hooks` v7's recommended set, so these diagnostics ship on by default. The opt-in `reactCompiler` layer promotes `unsupported-syntax`, `incompatible-library`, `immutability`, `purity`, `preserve-manual-memoization`, `set-state-in-render`, and `static-components` to `error`. (This replaces the previous hand-rolled `no-restricted-syntax` heuristics, which falsely flagged any optional chaining or `throw` inside a `try` block.)
+
+## 🛡️ Optional Hardening Layers
+
+These layers are off by default and enabled per project via `createConfig({ ... })` or their subpath exports.
+
+### `reanimated` / `worklets`
+
+- Flags reading a shared value (`.get()` / `.value`) inside a `useSharedValue(...)` initializer (render-time read).
+- Requires `.value` (not `.get()`) inside `useAnimatedStyle` / `useAnimatedReaction` / `useDerivedValue` / `useAnimatedProps` worklet hooks.
+- Flags inline gesture config objects passed to RNGH gesture hooks (default `usePanGesture`; extend with `gestureHooks` / `additionalGestureHooks`).
+- `worklets` flags inline callbacks passed to `scheduleOnRN` instead of a runtime function reference.
+
+**Rationale**: Reanimated runs worklet hooks across the JS/UI thread boundary; render-time shared-value reads and rebuilt gesture closures cause stale frames and dropped gestures.
+
+### `deprecatedApis`
+
+- Bans `MutableRefObject` (removed from React 19 typings; use `RefObject`).
+- Bans `StyleSheet.absoluteFillObject` (use `StyleSheet.absoluteFill`) and `AccessibilityInfo.setAccessibilityFocus` (use `sendAccessibilityEvent`).
+
+**Rationale**: Catches symbols removed or deprecated in React 19 / recent React Native at edit time rather than at upgrade time.
+
+### `componentStructure` (`expo-magic/*` plugin rules)
+
+- **`expo-magic/props-type-order`**: orders `*Props` members as required, optional, then function props, alphabetized within each group.
+- **`expo-magic/default-export-placement`**: requires `export default Component;` immediately after the component declaration.
+- **`expo-magic/no-inline-props`**: requires a named `type ...Props` alias instead of an inline object type on a `props` parameter.
+- **`expo-magic/require-children-usage`**: flags a declared `children` prop (or `PropsWithChildren`) that the component never renders.
+
+**Rationale**: Encodes component-authoring conventions that keep prop contracts and exports predictable across a large app.
+
+### `semanticColors`
+
+- Flags raw color literals (`#rrggbb`, `rgba()`, `hsla()`) and direct access to the raw color token map outside the token file.
+
+**Rationale**: Forces colors through semantic tokens so theming stays centralized. Configure `tokenModule`, `importName`, and `allowFiles` for your project layout.
+
+### `inlineStyles`
+
+- Enables `react-native/no-inline-styles` (default `warn`) for `.tsx` files.
 
 ## 📦 Imports & Organization
 

--- a/docs/CONFIG_DIFF.md
+++ b/docs/CONFIG_DIFF.md
@@ -1,6 +1,6 @@
 # Config Diff
 
-Package version: `2.6.0`
+Package version: `2.7.0`
 Expo config version: `56.0.4`
 
 ## Rule Counts
@@ -14,12 +14,16 @@ Expo config version: `56.0.4`
 | typed | 586 |
 | strict | 518 |
 | appGuardrails | 4 |
+| componentStructure | 4 |
+| deprecatedApis | 2 |
 | featureBoundaries | 1 |
 | nativeUi | 1 |
-| reactCompiler | 1 |
+| reactCompiler | 7 |
+| reanimated | 1 |
+| semanticColors | 1 |
 | storybook | 1 |
 | worklets | 1 |
-| productionApp | 520 |
+| productionApp | 526 |
 
 ## baseVsExpo
 
@@ -1021,6 +1025,12 @@ Expo config version: `56.0.4`
 ### Added
 
 - `@typescript-eslint/ban-ts-comment`
+- `@typescript-eslint/no-restricted-types`
+- `expo-magic/default-export-placement`
+- `expo-magic/no-inline-props`
+- `expo-magic/props-type-order`
+- `expo-magic/require-children-usage`
+- `no-restricted-properties`
 - `no-restricted-syntax`
 - `no-warning-comments`
 
@@ -1029,6 +1039,9 @@ Expo config version: `56.0.4`
 - `@typescript-eslint/no-non-null-assertion`
 - `no-console`
 - `no-restricted-imports`
+- `react-hooks/incompatible-library`
+- `react-hooks/unsupported-syntax`
+- `react-native/no-inline-styles`
 
 ### Removed
 

--- a/docs/RELEASE_NOTES.next.md
+++ b/docs/RELEASE_NOTES.next.md
@@ -1,6 +1,6 @@
 # Changes
 
-- Package version: `2.6.0`
+- Package version: `2.7.0`
 - Expo base version: `56.0.4`
 - Base preset vs Expo: 1 rule added, 0 rules changed, 40 rules removed.
   - Added: `expo/prefer-box-shadow`
@@ -11,9 +11,9 @@
 - no-prettier preset delta: `@babel/object-curly-spacing`, `@babel/semi`, `@stylistic/array-bracket-newline`, `@stylistic/array-bracket-spacing`, `@stylistic/array-element-newline`, `@stylistic/arrow-parens`, `@stylistic/arrow-spacing`, `@stylistic/block-spacing`, and 351 more
 - typed preset delta: `@typescript-eslint/adjacent-overload-signatures`, `@typescript-eslint/array-type`, `@typescript-eslint/ban-ts-comment`, `@typescript-eslint/ban-tslint-comment`, `@typescript-eslint/class-literal-property-style`, `@typescript-eslint/consistent-generic-constructors`, `@typescript-eslint/consistent-indexed-object-style`, `@typescript-eslint/consistent-type-assertions`, and 78 more
 - strict preset delta: `@typescript-eslint/no-misused-promises`, `@typescript-eslint/no-non-null-assertion`
-- Production app hardening vs default: 3 rules added, 3 rules changed, 0 rules removed.
-  - Added: `@typescript-eslint/ban-ts-comment`, `no-restricted-syntax`, `no-warning-comments`
-  - Changed: `@typescript-eslint/no-non-null-assertion`, `no-console`, `no-restricted-imports`
+- Production app hardening vs default: 9 rules added, 6 rules changed, 0 rules removed.
+  - Added: `@typescript-eslint/ban-ts-comment`, `@typescript-eslint/no-restricted-types`, `expo-magic/default-export-placement`, `expo-magic/no-inline-props`, `expo-magic/props-type-order`, `expo-magic/require-children-usage`, `no-restricted-properties`, `no-restricted-syntax`, and 1 more
+  - Changed: `@typescript-eslint/no-non-null-assertion`, `no-console`, `no-restricted-imports`, `react-hooks/incompatible-library`, `react-hooks/unsupported-syntax`, `react-native/no-inline-styles`
 - Upgrade notes:
   - Review `docs/CONFIG_DIFF.md` before upgrading.
   - If a new rule is too aggressive, recommend `base`, `no-prettier`, or `createConfig(...)` overrides.

--- a/docs/config-diff.json
+++ b/docs/config-diff.json
@@ -1,5 +1,5 @@
 {
-  "packageVersion": "2.6.0",
+  "packageVersion": "2.7.0",
   "expoConfigVersion": "56.0.4",
   "presets": {
     "expo": {
@@ -2553,6 +2553,48 @@
         ]
       }
     },
+    "componentStructure": {
+      "name": "componentStructure",
+      "ruleCount": 4,
+      "rules": {
+        "expo-magic/default-export-placement": "error",
+        "expo-magic/no-inline-props": "error",
+        "expo-magic/props-type-order": [
+          "warn"
+        ],
+        "expo-magic/require-children-usage": "warn"
+      }
+    },
+    "deprecatedApis": {
+      "name": "deprecatedApis",
+      "ruleCount": 2,
+      "rules": {
+        "@typescript-eslint/no-restricted-types": [
+          "error",
+          {
+            "types": {
+              "MutableRefObject": {
+                "message": "`MutableRefObject` is removed from React 19 typings. Use `RefObject` instead.",
+                "fixWith": "RefObject"
+              }
+            }
+          }
+        ],
+        "no-restricted-properties": [
+          "error",
+          {
+            "object": "StyleSheet",
+            "property": "absoluteFillObject",
+            "message": "`StyleSheet.absoluteFillObject` is deprecated. Use `StyleSheet.absoluteFill`."
+          },
+          {
+            "object": "AccessibilityInfo",
+            "property": "setAccessibilityFocus",
+            "message": "`AccessibilityInfo.setAccessibilityFocus` is deprecated. Use `AccessibilityInfo.sendAccessibilityEvent`."
+          }
+        ]
+      }
+    },
     "featureBoundaries": {
       "name": "featureBoundaries",
       "ruleCount": 1,
@@ -3132,23 +3174,47 @@
     },
     "reactCompiler": {
       "name": "reactCompiler",
+      "ruleCount": 7,
+      "rules": {
+        "react-hooks/immutability": "error",
+        "react-hooks/incompatible-library": "error",
+        "react-hooks/preserve-manual-memoization": "error",
+        "react-hooks/purity": "error",
+        "react-hooks/set-state-in-render": "error",
+        "react-hooks/static-components": "error",
+        "react-hooks/unsupported-syntax": "error"
+      }
+    },
+    "reanimated": {
+      "name": "reanimated",
       "ruleCount": 1,
       "rules": {
         "no-restricted-syntax": [
           "error",
           {
-            "selector": "TryStatement[finalizer!=null]",
-            "message": "React Compiler does not support try/finally in component or hook render scope. Use Promise.finally or explicit cleanup paths."
+            "selector": "CallExpression[callee.name=\"useSharedValue\"] > CallExpression[callee.property.name=\"get\"]",
+            "message": "Do not read a shared value with `.get()` inside `useSharedValue(...)`. Initialize from a plain value and sync in an effect or worklet reaction."
           },
           {
-            "selector": "TryStatement ThrowStatement",
-            "message": "React Compiler does not support throw inside try/catch in component or hook render scope. Prefer early returns and callback/onError handling."
+            "selector": "CallExpression[callee.name=\"useSharedValue\"] > MemberExpression[property.name=\"value\"]",
+            "message": "Do not read a shared value with `.value` inside `useSharedValue(...)`. Initialize from a plain value and sync in an effect or worklet reaction."
           },
           {
-            "selector": "TryStatement ChainExpression",
-            "message": "React Compiler can fail on optional chaining inside try/catch render scope. Resolve optional values before entering try/catch."
+            "selector": "CallExpression[callee.name=/^(useAnimatedStyle|useAnimatedReaction|useDerivedValue|useAnimatedProps)$/] CallExpression[callee.property.name=\"get\"]",
+            "message": "Use `.value`, not `.get()`, when reading shared values inside Reanimated worklet hooks."
+          },
+          {
+            "selector": "CallExpression[callee.name=/^(usePanGesture)$/] > ObjectExpression",
+            "message": "Memoize gesture config before passing it to RNGH gesture hooks so Reanimated does not rebuild worklet closures on every render."
           }
         ]
+      }
+    },
+    "semanticColors": {
+      "name": "semanticColors",
+      "ruleCount": 1,
+      "rules": {
+        "no-restricted-syntax": "off"
       }
     },
     "storybook": {
@@ -3177,7 +3243,7 @@
     },
     "productionApp": {
       "name": "productionApp",
-      "ruleCount": 520,
+      "ruleCount": 526,
       "rules": {
         "@babel/object-curly-spacing": "off",
         "@babel/semi": "off",
@@ -3431,6 +3497,17 @@
             ]
           }
         ],
+        "@typescript-eslint/no-restricted-types": [
+          "error",
+          {
+            "types": {
+              "MutableRefObject": {
+                "message": "`MutableRefObject` is removed from React 19 typings. Use `RefObject` instead.",
+                "fixWith": "RefObject"
+              }
+            }
+          }
+        ],
         "@typescript-eslint/no-unnecessary-type-assertion": "error",
         "@typescript-eslint/no-unnecessary-type-constraint": "error",
         "@typescript-eslint/no-unused-vars": [
@@ -3478,6 +3555,12 @@
           "warn",
           "smart"
         ],
+        "expo-magic/default-export-placement": "error",
+        "expo-magic/no-inline-props": "error",
+        "expo-magic/props-type-order": [
+          "warn"
+        ],
+        "expo-magic/require-children-usage": "warn",
         "expo/no-dynamic-env-var": [
           "error"
         ],
@@ -3719,41 +3802,20 @@
             ]
           }
         ],
-        "no-restricted-syntax": [
+        "no-restricted-properties": [
           "error",
           {
-            "selector": "TSAsExpression > TSAsExpression",
-            "message": "Avoid double type assertions. Prefer proper type guards or generic typing."
+            "object": "StyleSheet",
+            "property": "absoluteFillObject",
+            "message": "`StyleSheet.absoluteFillObject` is deprecated. Use `StyleSheet.absoluteFill`."
           },
           {
-            "selector": "TSTypeReference[typeName.name=\"ReturnType\"] TSTypeQuery > Identifier[name=/^useGet[A-Z]/]",
-            "message": "Avoid `ReturnType<typeof useGet...>` with selector-capable query hooks. Use domain types or shared query-result helpers."
-          },
-          {
-            "selector": "CallExpression[callee.property.name=\"toMatchSnapshot\"], CallExpression[callee.name=\"toMatchSnapshot\"]",
-            "message": "Prefer focused assertions over snapshots for production app regressions."
-          },
-          {
-            "selector": "TryStatement[finalizer!=null]",
-            "message": "React Compiler does not support try/finally in component or hook render scope. Use Promise.finally or explicit cleanup paths."
-          },
-          {
-            "selector": "TryStatement ThrowStatement",
-            "message": "React Compiler does not support throw inside try/catch in component or hook render scope. Prefer early returns and callback/onError handling."
-          },
-          {
-            "selector": "TryStatement ChainExpression",
-            "message": "React Compiler can fail on optional chaining inside try/catch render scope. Resolve optional values before entering try/catch."
-          },
-          {
-            "selector": "CallExpression[callee.name=\"scheduleOnRN\"] > ArrowFunctionExpression",
-            "message": "Pass an RN-runtime function reference to `scheduleOnRN` instead of an inline callback."
-          },
-          {
-            "selector": "CallExpression[callee.name=\"scheduleOnRN\"] > FunctionExpression",
-            "message": "Pass an RN-runtime function reference to `scheduleOnRN` instead of an inline callback."
+            "object": "AccessibilityInfo",
+            "property": "setAccessibilityFocus",
+            "message": "`AccessibilityInfo.setAccessibilityFocus` is deprecated. Use `AccessibilityInfo.sendAccessibilityEvent`."
           }
         ],
+        "no-restricted-syntax": "off",
         "no-space-before-semi": "off",
         "no-spaced-func": "off",
         "no-tabs": 0,
@@ -3815,7 +3877,7 @@
         "react-hooks/gating": "error",
         "react-hooks/globals": "error",
         "react-hooks/immutability": "error",
-        "react-hooks/incompatible-library": "warn",
+        "react-hooks/incompatible-library": "error",
         "react-hooks/preserve-manual-memoization": "error",
         "react-hooks/purity": "error",
         "react-hooks/refs": "error",
@@ -3823,9 +3885,9 @@
         "react-hooks/set-state-in-effect": "off",
         "react-hooks/set-state-in-render": "error",
         "react-hooks/static-components": "error",
-        "react-hooks/unsupported-syntax": "warn",
+        "react-hooks/unsupported-syntax": "error",
         "react-hooks/use-memo": "error",
-        "react-native/no-inline-styles": "off",
+        "react-native/no-inline-styles": "warn",
         "react-native/no-raw-text": "off",
         "react-native/no-single-element-style-arrays": "error",
         "react-native/no-unused-styles": "error",
@@ -4927,6 +4989,12 @@
     "productionAppVsDefault": {
       "added": [
         "@typescript-eslint/ban-ts-comment",
+        "@typescript-eslint/no-restricted-types",
+        "expo-magic/default-export-placement",
+        "expo-magic/no-inline-props",
+        "expo-magic/props-type-order",
+        "expo-magic/require-children-usage",
+        "no-restricted-properties",
         "no-restricted-syntax",
         "no-warning-comments"
       ],
@@ -4934,7 +5002,10 @@
       "changed": [
         "@typescript-eslint/no-non-null-assertion",
         "no-console",
-        "no-restricted-imports"
+        "no-restricted-imports",
+        "react-hooks/incompatible-library",
+        "react-hooks/unsupported-syntax",
+        "react-native/no-inline-styles"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 	"private": true,
 	"scripts": {
 		"test": "bun test packages/eslint-config-expo-magic/index.test.ts",
+		"typecheck": "cd packages/eslint-config-expo-magic && bun run typecheck",
 		"check-pm": "node packages/eslint-config-expo-magic/check-pm.js",
 		"ci": "bun install --frozen-lockfile",
 		"validate": "cd test-project && bun run validate",

--- a/packages/eslint-config-expo-magic/component-structure.d.ts
+++ b/packages/eslint-config-expo-magic/component-structure.d.ts
@@ -1,0 +1,19 @@
+import type { ESLint, Linter } from 'eslint';
+
+type ComponentStructureOptions = {
+	propsTypePattern?: string;
+};
+
+declare const componentStructureConfig: Linter.Config[] & {
+	createComponentStructureConfig(
+		options?: ComponentStructureOptions,
+	): Linter.Config[];
+	plugin: ESLint.Plugin;
+	recommended: Linter.Config[];
+};
+
+declare namespace componentStructureConfig {
+	export { ComponentStructureOptions };
+}
+
+export = componentStructureConfig;

--- a/packages/eslint-config-expo-magic/component-structure.js
+++ b/packages/eslint-config-expo-magic/component-structure.js
@@ -1,0 +1,1 @@
+module.exports = require('./utils/component-structure.js');

--- a/packages/eslint-config-expo-magic/component-structure.mjs
+++ b/packages/eslint-config-expo-magic/component-structure.mjs
@@ -1,0 +1,10 @@
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const componentStructure = require('./component-structure.js');
+
+export default componentStructure;
+export const createComponentStructureConfig =
+	componentStructure.createComponentStructureConfig;
+export const plugin = componentStructure.plugin;
+export const recommended = componentStructure.recommended;

--- a/packages/eslint-config-expo-magic/deprecated-apis.d.ts
+++ b/packages/eslint-config-expo-magic/deprecated-apis.d.ts
@@ -1,0 +1,37 @@
+import type { Linter } from 'eslint';
+
+type DeprecatedApiRestrictedProperty = {
+	object?: string;
+	property?: string;
+	message?: string;
+};
+
+type DeprecatedApiRestrictedType = {
+	message?: string;
+	fixWith?: string;
+};
+
+type DeprecatedApiOptions = {
+	additionalRestrictedProperties?: DeprecatedApiRestrictedProperty[];
+	additionalRestrictedTypes?: Record<
+		string,
+		string | DeprecatedApiRestrictedType
+	>;
+};
+
+declare const deprecatedApisConfig: Linter.Config[] & {
+	createDeprecatedApiConfig(options?: DeprecatedApiOptions): Linter.Config[];
+	defaultRestrictedProperties: DeprecatedApiRestrictedProperty[];
+	defaultRestrictedTypes: Record<string, DeprecatedApiRestrictedType>;
+	recommended: Linter.Config[];
+};
+
+declare namespace deprecatedApisConfig {
+	export {
+		DeprecatedApiOptions,
+		DeprecatedApiRestrictedProperty,
+		DeprecatedApiRestrictedType,
+	};
+}
+
+export = deprecatedApisConfig;

--- a/packages/eslint-config-expo-magic/deprecated-apis.js
+++ b/packages/eslint-config-expo-magic/deprecated-apis.js
@@ -1,0 +1,1 @@
+module.exports = require('./utils/deprecated-apis.js');

--- a/packages/eslint-config-expo-magic/deprecated-apis.mjs
+++ b/packages/eslint-config-expo-magic/deprecated-apis.mjs
@@ -1,0 +1,12 @@
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const deprecatedApis = require('./deprecated-apis.js');
+
+export default deprecatedApis;
+export const createDeprecatedApiConfig =
+	deprecatedApis.createDeprecatedApiConfig;
+export const defaultRestrictedProperties =
+	deprecatedApis.defaultRestrictedProperties;
+export const defaultRestrictedTypes = deprecatedApis.defaultRestrictedTypes;
+export const recommended = deprecatedApis.recommended;

--- a/packages/eslint-config-expo-magic/index.d.ts
+++ b/packages/eslint-config-expo-magic/index.d.ts
@@ -39,36 +39,118 @@ type FeatureBoundaryOptions = {
 	additionalSharedComponentPatterns?: string[];
 };
 
+type AppGuardrailsOptions = {
+	queryHookPattern?: string;
+};
+
+type ComponentStructureOptions = {
+	propsTypePattern?: string;
+};
+
+type DeprecatedApiRestrictedProperty = {
+	object?: string;
+	property?: string;
+	message?: string;
+};
+
+type DeprecatedApiRestrictedType = {
+	message?: string;
+	fixWith?: string;
+};
+
+type DeprecatedApiOptions = {
+	additionalRestrictedProperties?: DeprecatedApiRestrictedProperty[];
+	additionalRestrictedTypes?: Record<
+		string,
+		string | DeprecatedApiRestrictedType
+	>;
+};
+
+type ReanimatedOptions = {
+	gestureHooks?: string[];
+	additionalGestureHooks?: string[];
+};
+
+type SemanticColorsOptions = {
+	tokenModule?: string;
+	importName?: string;
+	flagDirectAccess?: boolean;
+	allowFiles?: string[];
+};
+
+type CreateConfigOptions = {
+	preset?: 'base' | 'default';
+	prettier?: boolean;
+	testing?: boolean;
+	typeChecked?: boolean;
+	strict?: boolean;
+	tsconfigProjects?: string[];
+	extraIgnores?: string[];
+	appGuardrails?: boolean | AppGuardrailsOptions;
+	componentStructure?: boolean | ComponentStructureOptions;
+	deprecatedApis?: boolean | DeprecatedApiOptions;
+	featureBoundaries?: boolean | FeatureBoundaryOptions;
+	inlineStyles?: boolean | Linter.RuleLevel;
+	nativeUi?: boolean | NativeUiOptions;
+	reactCompiler?: boolean;
+	reanimated?: boolean | ReanimatedOptions;
+	semanticColors?: boolean | SemanticColorsOptions;
+	storybook?: boolean;
+	worklets?: boolean;
+};
+
+type ReactCompilerConfig = FlatConfig[] & {
+	rules: Record<string, Linter.RuleEntry>;
+};
+
 declare const config: FlatConfig[] & {
 	base: FlatConfig[];
-	createConfig(options?: {
-		preset?: 'base' | 'default';
-		prettier?: boolean;
-		testing?: boolean;
-		typeChecked?: boolean;
-		strict?: boolean;
-		tsconfigProjects?: string[];
-		extraIgnores?: string[];
-		appGuardrails?: boolean;
-		featureBoundaries?: boolean | FeatureBoundaryOptions;
-		nativeUi?: boolean | NativeUiOptions;
-		reactCompiler?: boolean;
-		storybook?: boolean;
-		worklets?: boolean;
-	}): FlatConfig[];
+	createConfig(options?: CreateConfigOptions): FlatConfig[];
 	strict: FlatConfig[];
 	typed: FlatConfig[];
 	noPrettier: FlatConfig[];
 	strictNoPrettier: FlatConfig[];
 	typedNoPrettier: FlatConfig[];
 	appGuardrails: AppGuardrailsConfig;
+	createAppGuardrailsConfig(options?: AppGuardrailsOptions): FlatConfig[];
+	componentStructure: FlatConfig[];
+	createComponentStructureConfig(
+		options?: ComponentStructureOptions,
+	): FlatConfig[];
+	deprecatedApis: FlatConfig[];
+	createDeprecatedApiConfig(options?: DeprecatedApiOptions): FlatConfig[];
 	createFeatureBoundaryConfig(options?: FeatureBoundaryOptions): FlatConfig[];
 	createNativeUiConfig(options?: NativeUiOptions): FlatConfig[];
 	featureBoundaries: FlatConfig[];
 	nativeUi: FlatConfig[];
-	reactCompiler: RestrictedSyntaxConfig;
+	reactCompiler: ReactCompilerConfig;
+	reanimated: FlatConfig[];
+	createReanimatedConfig(options?: ReanimatedOptions): FlatConfig[];
+	semanticColors: FlatConfig[];
+	createSemanticColorsConfig(options?: SemanticColorsOptions): FlatConfig[];
 	storybook: FlatConfig[];
 	worklets: RestrictedSyntaxConfig;
 };
+
+declare namespace config {
+	export {
+		AppGuardrailsConfig,
+		AppGuardrailsOptions,
+		ComponentStructureOptions,
+		CreateConfigOptions,
+		DeprecatedApiOptions,
+		DeprecatedApiRestrictedProperty,
+		DeprecatedApiRestrictedType,
+		FeatureBoundaryOptions,
+		NativeUiOptions,
+		NativeUiRestriction,
+		ReactCompilerConfig,
+		ReanimatedOptions,
+		RestrictedSyntaxConfig,
+		RestrictedSyntaxGroup,
+		RestrictedSyntaxSelector,
+		SemanticColorsOptions,
+	};
+}
 
 export = config;

--- a/packages/eslint-config-expo-magic/index.js
+++ b/packages/eslint-config-expo-magic/index.js
@@ -9,6 +9,8 @@ const tseslint = require('typescript-eslint');
 
 const appConfig = require('./utils/app.js');
 const appGuardrailsConfig = require('./utils/app-guardrails.js');
+const componentStructureConfig = require('./utils/component-structure.js');
+const deprecatedApisConfig = require('./utils/deprecated-apis.js');
 const allExtensions = require('./utils/extensions.js');
 const featureBoundaryConfig = require('./utils/feature-boundaries.js');
 const importsConfig = require('./utils/imports.js');
@@ -17,9 +19,11 @@ const nativeUiConfig = require('./utils/native-ui.js');
 const prettierConfig = require('./utils/prettier.js');
 const reactConfig = require('./utils/react.js');
 const reactCompilerConfig = require('./utils/react-compiler.js');
+const reanimatedConfig = require('./utils/reanimated.js');
 const {
 	createComposedRestrictedSyntaxConfigs,
 } = require('./utils/restricted-syntax.js');
+const semanticColorsConfig = require('./utils/semantic-colors.js');
 const storybookConfig = require('./utils/storybook.js');
 const typescriptConfig = require('./utils/typescript.js');
 const workletsConfig = require('./utils/worklets.js');
@@ -131,9 +135,8 @@ function createTypeScriptImportResolverConfig(tsconfigProjects) {
 }
 
 function createSharedConfig(tsconfigProjects, extraIgnores = []) {
-	const typescriptImportResolver = createTypeScriptImportResolverConfig(
-		tsconfigProjects,
-	);
+	const typescriptImportResolver =
+		createTypeScriptImportResolverConfig(tsconfigProjects);
 	const importXResolvers = [
 		createTypeScriptImportResolver(typescriptImportResolver),
 		createNodeResolver({ extensions: allExtensions }),
@@ -281,13 +284,19 @@ function createConfig(options = {}) {
 		tsconfigProjects = defaultTsconfigProjectGlobs,
 		extraIgnores = [],
 		appGuardrails = false,
+		componentStructure = false,
+		deprecatedApis = false,
 		featureBoundaries = false,
+		inlineStyles = false,
 		nativeUi = false,
 		reactCompiler = false,
+		reanimated = false,
+		semanticColors = false,
 		storybook = false,
 		worklets = false,
 	} = options;
 	const restrictedSyntaxGroups = [];
+	const postCompositionConfig = [];
 
 	const presetConfig =
 		preset === 'base'
@@ -297,8 +306,30 @@ function createConfig(options = {}) {
 	const finalConfig = [...presetConfig];
 
 	if (appGuardrails) {
+		const appGuardrailsOptions =
+			appGuardrails === true ? undefined : appGuardrails;
 		finalConfig.push(...appGuardrailsConfig.base);
-		restrictedSyntaxGroups.push(...appGuardrailsConfig.restrictedSyntaxGroups);
+		restrictedSyntaxGroups.push(
+			...appGuardrailsConfig.createRestrictedSyntaxGroups(appGuardrailsOptions),
+		);
+	}
+
+	if (componentStructure) {
+		finalConfig.push(
+			...normalizeOptionConfig(
+				componentStructure,
+				componentStructureConfig.createComponentStructureConfig,
+			),
+		);
+	}
+
+	if (deprecatedApis) {
+		finalConfig.push(
+			...normalizeOptionConfig(
+				deprecatedApis,
+				deprecatedApisConfig.createDeprecatedApiConfig,
+			),
+		);
 	}
 
 	if (featureBoundaries) {
@@ -310,6 +341,16 @@ function createConfig(options = {}) {
 		);
 	}
 
+	if (inlineStyles && preset !== 'base') {
+		finalConfig.push({
+			files: ['**/*.tsx'],
+			rules: {
+				'react-native/no-inline-styles':
+					inlineStyles === true ? 'warn' : inlineStyles,
+			},
+		});
+	}
+
 	if (nativeUi) {
 		finalConfig.push(
 			...normalizeOptionConfig(nativeUi, nativeUiConfig.createNativeUiConfig),
@@ -317,7 +358,27 @@ function createConfig(options = {}) {
 	}
 
 	if (reactCompiler) {
-		restrictedSyntaxGroups.push(...reactCompilerConfig.restrictedSyntaxGroups);
+		finalConfig.push({ rules: { ...reactCompilerConfig.rules } });
+	}
+
+	if (reanimated) {
+		const reanimatedOptions = reanimated === true ? undefined : reanimated;
+		restrictedSyntaxGroups.push(
+			...reanimatedConfig.createRestrictedSyntaxGroups(reanimatedOptions),
+		);
+	}
+
+	if (semanticColors) {
+		const semanticColorsOptions =
+			semanticColors === true ? undefined : semanticColors;
+		restrictedSyntaxGroups.push(
+			...semanticColorsConfig.createRestrictedSyntaxGroups(
+				semanticColorsOptions,
+			),
+		);
+		postCompositionConfig.push(
+			...semanticColorsConfig.createAllowConfig(semanticColorsOptions),
+		);
 	}
 
 	if (storybook) {
@@ -332,6 +393,10 @@ function createConfig(options = {}) {
 		finalConfig.push(
 			...createComposedRestrictedSyntaxConfigs(restrictedSyntaxGroups),
 		);
+	}
+
+	if (postCompositionConfig.length > 0) {
+		finalConfig.push(...postCompositionConfig);
 	}
 
 	if (typeChecked) {
@@ -384,11 +449,24 @@ module.exports.noPrettier = noPrettier;
 module.exports.strictNoPrettier = strictNoPrettier;
 module.exports.typedNoPrettier = typedNoPrettier;
 module.exports.appGuardrails = appGuardrailsConfig;
+module.exports.createAppGuardrailsConfig =
+	appGuardrailsConfig.createAppGuardrailsConfig;
+module.exports.componentStructure = componentStructureConfig.recommended;
+module.exports.createComponentStructureConfig =
+	componentStructureConfig.createComponentStructureConfig;
+module.exports.deprecatedApis = deprecatedApisConfig.recommended;
+module.exports.createDeprecatedApiConfig =
+	deprecatedApisConfig.createDeprecatedApiConfig;
 module.exports.createFeatureBoundaryConfig =
 	featureBoundaryConfig.createFeatureBoundaryConfig;
 module.exports.createNativeUiConfig = nativeUiConfig.createNativeUiConfig;
 module.exports.featureBoundaries = featureBoundaryConfig.recommended;
 module.exports.nativeUi = nativeUiConfig.recommended;
 module.exports.reactCompiler = reactCompilerConfig;
+module.exports.reanimated = reanimatedConfig;
+module.exports.createReanimatedConfig = reanimatedConfig.createReanimatedConfig;
+module.exports.semanticColors = semanticColorsConfig;
+module.exports.createSemanticColorsConfig =
+	semanticColorsConfig.createSemanticColorsConfig;
 module.exports.storybook = storybookConfig;
 module.exports.worklets = workletsConfig;

--- a/packages/eslint-config-expo-magic/index.test.ts
+++ b/packages/eslint-config-expo-magic/index.test.ts
@@ -5,6 +5,8 @@ const fs = require('node:fs');
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 const { pathToFileURL } = require('node:url');
+const { RuleTester } = require('eslint');
+const tsParser = require('@typescript-eslint/parser');
 const expoFlatConfig = require('eslint-config-expo/flat');
 const { createConfigReport } = require('../../scripts/lib/config-report.js');
 const config = require('./index.js');
@@ -13,12 +15,17 @@ const strictSubpath = require('./strict.js');
 const noPrettierSubpath = require('./no-prettier.js');
 const typedSubpath = require('./typed.js');
 const appGuardrailsSubpath = require('./app-guardrails.js');
+const componentStructureSubpath = require('./component-structure.js');
+const deprecatedApisSubpath = require('./deprecated-apis.js');
 const featureBoundariesSubpath = require('./feature-boundaries.js');
 const nativeUiSubpath = require('./native-ui.js');
 const prGuardrails = require('./pr-guardrails.js');
 const reactCompilerSubpath = require('./react-compiler.js');
+const reanimatedSubpath = require('./reanimated.js');
+const semanticColorsSubpath = require('./semantic-colors.js');
 const storybookSubpath = require('./storybook.js');
 const workletsSubpath = require('./worklets.js');
+const expoMagicPlugin = require('./utils/plugin/index.js');
 
 type FlatConfig = Linter.Config;
 const rootDir = path.resolve(__dirname, '../..');
@@ -809,7 +816,7 @@ describe('eslint-config-expo-magic', () => {
 				expect(
 					messages.filter((message) => message.ruleId === 'no-restricted-syntax')
 						.length,
-				).toBeGreaterThanOrEqual(4);
+				).toBeGreaterThanOrEqual(3);
 				expect(
 					messages.some((message) => message.ruleId === 'no-console'),
 				).toBe(false);
@@ -1486,6 +1493,458 @@ describe('eslint-config-expo-magic', () => {
 					false,
 				);
 			}
+		});
+	});
+
+	describe('expo-magic plugin rules', () => {
+		RuleTester.describe = describe;
+		RuleTester.it = it;
+		RuleTester.itOnly = (it as { only?: typeof it }).only ?? it;
+
+		const ruleTester = new RuleTester({
+			languageOptions: {
+				parser: tsParser,
+				parserOptions: {
+					sourceType: 'module',
+					ecmaFeatures: { jsx: true },
+				},
+			},
+		});
+
+		ruleTester.run(
+			'props-type-order',
+			expoMagicPlugin.rules['props-type-order'],
+			{
+				valid: [
+					'type FooProps = { id: string; title: string; onPress: () => void; };',
+					'type FooProps = { id: string; label?: string; onChange: () => void; };',
+					'type Other = { b: string; a: string; };',
+					'type FooProps = { value: string; };',
+				],
+				invalid: [
+					{
+						code: 'type FooProps = { onPress: () => void; title: string; };',
+						errors: [{ messageId: 'order' }],
+					},
+					{
+						code: 'type BarProps = { b: string; a: string; };',
+						errors: [{ messageId: 'order' }],
+					},
+					{
+						code: 'type FooProps = { label?: string; id: string; };',
+						errors: [{ messageId: 'order' }],
+					},
+				],
+			},
+		);
+
+		ruleTester.run(
+			'default-export-placement',
+			expoMagicPlugin.rules['default-export-placement'],
+			{
+				valid: [
+					'const Foo = () => null;\nexport default Foo;',
+					'function Foo() { return null; }\nexport default Foo;',
+					"import Foo from './foo';\nexport default Foo;",
+					'const foo = 1;\nconst bar = 2;\nexport default foo;',
+				],
+				invalid: [
+					{
+						code: 'const Foo = () => null;\nconst helper = () => null;\nexport default Foo;',
+						errors: [{ messageId: 'placement' }],
+					},
+					{
+						code: 'function Foo() { return null; }\nconst styles = {};\nexport default Foo;',
+						errors: [{ messageId: 'placement' }],
+					},
+				],
+			},
+		);
+
+		ruleTester.run('no-inline-props', expoMagicPlugin.rules['no-inline-props'], {
+			valid: [
+				'type P = { a: string };\nfunction Foo(props: P) { return props; }',
+				'function Foo(value: { a: string }) { return value; }',
+			],
+			invalid: [
+				{
+					code: 'function Foo(props: { a: string }) { return props; }',
+					errors: [{ messageId: 'inline' }],
+				},
+				{
+					code: 'const Foo = (props: { a: string }) => props;',
+					errors: [{ messageId: 'inline' }],
+				},
+			],
+		});
+
+		ruleTester.run(
+			'require-children-usage',
+			expoMagicPlugin.rules['require-children-usage'],
+			{
+				valid: [
+					'type P = { children: unknown };\nconst Foo = (props: P) => props.children;',
+					'function Foo({ children }: { children: unknown }) { return children; }',
+					'type P = { title: string };\nconst Foo = (props: P) => props.title;',
+					'import type { PropsWithChildren } from "react";\nconst Foo = (props: PropsWithChildren) => props.children;',
+				],
+				invalid: [
+					{
+						code: 'type P = { children: unknown };\nconst Foo = (props: P) => null;',
+						errors: [{ messageId: 'unused' }],
+					},
+					{
+						code: 'import type { PropsWithChildren } from "react";\nconst Foo = (props: PropsWithChildren) => null;',
+						errors: [{ messageId: 'unused' }],
+					},
+				],
+			},
+		);
+	});
+
+	describe('reanimated rules', () => {
+		it('flags shared-value reads, hook .get(), and inline gesture config', () => {
+			const messages = runFixtureLint({
+				configSource: createPackageConfigSource(`{
+					prettier: false,
+					testing: false,
+					reanimated: true
+				}`),
+				files: {
+					'anim.ts': [
+						'declare const other: { get(): number; value: number };',
+						'declare function useSharedValue<T>(v: T): { get(): T; value: T };',
+						'declare function useAnimatedStyle(cb: () => object): object;',
+						'declare function usePanGesture(cfg: object): object;',
+						'export function build() {',
+						'\tconst fromGet = useSharedValue(other.get());',
+						'\tconst fromValue = useSharedValue(other.value);',
+						'\tconst style = useAnimatedStyle(() => ({ x: other.get() }));',
+						'\tconst gesture = usePanGesture({ onStart: () => {} });',
+						'\treturn [fromGet, fromValue, style, gesture];',
+						'}',
+						'',
+					].join('\n'),
+				},
+			});
+
+			expect(
+				messages.filter((message) => message.ruleId === 'no-restricted-syntax'),
+			).toHaveLength(4);
+		}, 15_000);
+
+		it('supports custom gesture hook names', () => {
+			const messages = runFixtureLint({
+				configSource: createPackageConfigSource(`{
+					prettier: false,
+					testing: false,
+					reanimated: { additionalGestureHooks: ['useFlingGesture'] }
+				}`),
+				files: {
+					'gesture.ts': [
+						'declare function useFlingGesture(cfg: object): object;',
+						'export function build() {',
+						'\treturn useFlingGesture({ onStart: () => {} });',
+						'}',
+						'',
+					].join('\n'),
+				},
+			});
+
+			expect(
+				messages.some((message) => message.ruleId === 'no-restricted-syntax'),
+			).toBe(true);
+		}, 15_000);
+
+		it('composes reanimated and worklets selectors without clobbering', () => {
+			const messages = runFixtureLint({
+				configSource: createPackageConfigSource(`{
+					prettier: false,
+					testing: false,
+					reanimated: true,
+					worklets: true
+				}`),
+				files: {
+					'compose.ts': [
+						'declare const other: { value: number };',
+						'declare function useSharedValue<T>(v: T): { value: T };',
+						'declare function scheduleOnRN(callback: () => void): void;',
+						'export function build() {',
+						'\tconst shared = useSharedValue(other.value);',
+						'\tscheduleOnRN(() => {});',
+						'\treturn shared;',
+						'}',
+						'',
+					].join('\n'),
+				},
+			});
+
+			expect(
+				messages.filter((message) => message.ruleId === 'no-restricted-syntax'),
+			).toHaveLength(2);
+		}, 15_000);
+	});
+
+	describe('deprecated api rules', () => {
+		it('flags deprecated symbols and types', () => {
+			const messages = runFixtureLint({
+				configSource: createPackageConfigSource(`{
+					prettier: false,
+					testing: false,
+					deprecatedApis: true
+				}`),
+				files: {
+					'legacy.ts': [
+						'declare const StyleSheet: { absoluteFillObject: object };',
+						'declare const AccessibilityInfo: { setAccessibilityFocus: () => void };',
+						'export const fill = StyleSheet.absoluteFillObject;',
+						'export function focus() { AccessibilityInfo.setAccessibilityFocus(); }',
+						'export let nodeRef: MutableRefObject<number>;',
+						'',
+					].join('\n'),
+				},
+			});
+
+			expect(
+				messages.filter((message) => message.ruleId === 'no-restricted-properties'),
+			).toHaveLength(2);
+			expect(
+				messages.some(
+					(message) =>
+						message.ruleId === '@typescript-eslint/no-restricted-types',
+				),
+			).toBe(true);
+		}, 15_000);
+
+		it('accepts additional restricted properties', () => {
+			const deprecated = config.createDeprecatedApiConfig({
+				additionalRestrictedProperties: [
+					{ object: 'Foo', property: 'bar', message: 'No.' },
+				],
+			});
+			const propertiesEntry = deprecated.find(
+				(entry: FlatConfig) => entry.rules?.['no-restricted-properties'],
+			);
+
+			expect(propertiesEntry.rules['no-restricted-properties']).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({ object: 'Foo', property: 'bar' }),
+					expect.objectContaining({
+						object: 'StyleSheet',
+						property: 'absoluteFillObject',
+					}),
+				]),
+			);
+		});
+	});
+
+	describe('semantic colors rules', () => {
+		it('flags raw colors and direct token access but allows the token file', () => {
+			const messages = runFixtureLint({
+				configSource: createPackageConfigSource(`{
+					prettier: false,
+					testing: false,
+					semanticColors: true
+				}`),
+				files: {
+					'screen.ts': [
+						"import { colors } from '../uikit/tokens/colors';",
+						"export const hex = '#ffffff';",
+						"export const translucent = 'rgba(0,0,0,0.5)';",
+						'export const raw = colors.primary;',
+						'',
+					].join('\n'),
+					'uikit/tokens/colors.ts': [
+						"export const colors = { primary: '#ff0000' };",
+						'',
+					].join('\n'),
+				},
+			});
+
+			const screenMessages = messages.filter(
+				(message) => message.ruleId === 'no-restricted-syntax',
+			);
+
+			expect(screenMessages.length).toBeGreaterThanOrEqual(4);
+		}, 15_000);
+
+		it('supports a custom token module path', () => {
+			const groups = config.createSemanticColorsConfig({
+				tokenModule: 'theme/palette',
+				importName: 'palette',
+			});
+			const restrictionEntry = groups.find(
+				(entry: FlatConfig) => entry.rules?.['no-restricted-syntax'],
+			);
+			const selectors = restrictionEntry.rules['no-restricted-syntax'].slice(1);
+
+			expect(
+				selectors.some((selector: { selector: string }) =>
+					selector.selector.includes('theme\\/palette'),
+				),
+			).toBe(true);
+			expect(
+				selectors.some((selector: { selector: string }) =>
+					selector.selector.includes('object.name="palette"'),
+				),
+			).toBe(true);
+		});
+	});
+
+	describe('component structure rules', () => {
+		it('runs component structure rules end to end', () => {
+			const messages = runFixtureLint({
+				configSource: createPackageConfigSource(`{
+					prettier: false,
+					testing: false,
+					componentStructure: true
+				}`),
+				files: {
+					'Widget.tsx': [
+						'type WidgetProps = {',
+						'\tonPress: () => void;',
+						'\ttitle: string;',
+						'};',
+						'const Widget = (props: WidgetProps) => props.title;',
+						'const helper = () => null;',
+						'export default Widget;',
+						'export const noop = helper;',
+						'',
+					].join('\n'),
+				},
+			});
+
+			expect(
+				messages.some(
+					(message) => message.ruleId === 'expo-magic/props-type-order',
+				),
+			).toBe(true);
+			expect(
+				messages.some(
+					(message) =>
+						message.ruleId === 'expo-magic/default-export-placement',
+				),
+			).toBe(true);
+		}, 15_000);
+
+		it('supports a custom props type pattern', () => {
+			const structure = config.createComponentStructureConfig({
+				propsTypePattern: '^Settings$',
+			});
+			const propTypeEntry = structure.find(
+				(entry: FlatConfig) =>
+					entry.rules?.['expo-magic/props-type-order'] &&
+					entry.files?.includes('**/*.ts'),
+			);
+
+			expect(propTypeEntry.rules['expo-magic/props-type-order']).toEqual([
+				'warn',
+				{ pattern: '^Settings$' },
+			]);
+		});
+	});
+
+	describe('react compiler preset', () => {
+		it('promotes react-hooks compiler diagnostics to error', () => {
+			expect(reactCompilerSubpath.rules['react-hooks/unsupported-syntax']).toBe(
+				'error',
+			);
+			expect(reactCompilerSubpath.rules['react-hooks/incompatible-library']).toBe(
+				'error',
+			);
+		});
+
+		it('no longer ships brittle restricted-syntax selectors', () => {
+			expect(reactCompilerSubpath.restrictedSyntaxGroups).toBeUndefined();
+			const composed = config.createConfig({ reactCompiler: true });
+			const compilerEntry = composed.find(
+				(entry: FlatConfig) =>
+					entry.rules?.['react-hooks/unsupported-syntax'] === 'error',
+			);
+			expect(compilerEntry).toBeDefined();
+		});
+	});
+
+	describe('app guardrails options', () => {
+		it('supports a custom query hook pattern', () => {
+			const groups = config.createAppGuardrailsConfig({
+				queryHookPattern: '^useFetch[A-Z]',
+			});
+			const restrictionEntry = groups.find(
+				(entry: FlatConfig) => entry.rules?.['no-restricted-syntax'],
+			);
+			const selectors = restrictionEntry.rules['no-restricted-syntax'].slice(1);
+
+			expect(
+				selectors.some((selector: { selector: string }) =>
+					selector.selector.includes('^useFetch[A-Z]'),
+				),
+			).toBe(true);
+		});
+	});
+
+	describe('inline styles option', () => {
+		it('enables react-native/no-inline-styles when requested', () => {
+			const customConfig = config.createConfig({ inlineStyles: true });
+			const inlineStylesEntry = customConfig.find(
+				(entry: FlatConfig) =>
+					entry.rules?.['react-native/no-inline-styles'] === 'warn',
+			);
+
+			expect(inlineStylesEntry).toBeDefined();
+			expect(inlineStylesEntry.files).toContain('**/*.tsx');
+		});
+
+		it('keeps inline styles disabled by default', () => {
+			const inlineStylesEntry = config.find(
+				(entry: FlatConfig) =>
+					entry.rules?.['react-native/no-inline-styles'] === 'warn',
+			);
+			expect(inlineStylesEntry).toBeUndefined();
+		});
+	});
+
+	describe('new subpath exports', () => {
+		it('exports component structure, deprecated apis, reanimated, semantic colors', () => {
+			expect(typeof componentStructureSubpath.createComponentStructureConfig).toBe(
+				'function',
+			);
+			expect(typeof deprecatedApisSubpath.createDeprecatedApiConfig).toBe(
+				'function',
+			);
+			expect(typeof reanimatedSubpath.createReanimatedConfig).toBe('function');
+			expect(typeof semanticColorsSubpath.createSemanticColorsConfig).toBe(
+				'function',
+			);
+			expect(Array.isArray(componentStructureSubpath)).toBe(true);
+			expect(Array.isArray(deprecatedApisSubpath)).toBe(true);
+			expect(Array.isArray(reanimatedSubpath)).toBe(true);
+			expect(Array.isArray(semanticColorsSubpath)).toBe(true);
+		});
+
+		it('supports ESM entrypoints for new subpaths', async () => {
+			const componentStructureEsm = await import(
+				pathToFileURL(path.join(__dirname, 'component-structure.mjs')).href
+			);
+			const deprecatedApisEsm = await import(
+				pathToFileURL(path.join(__dirname, 'deprecated-apis.mjs')).href
+			);
+			const reanimatedEsm = await import(
+				pathToFileURL(path.join(__dirname, 'reanimated.mjs')).href
+			);
+			const semanticColorsEsm = await import(
+				pathToFileURL(path.join(__dirname, 'semantic-colors.mjs')).href
+			);
+
+			expect(Array.isArray(componentStructureEsm.default)).toBe(true);
+			expect(typeof componentStructureEsm.createComponentStructureConfig).toBe(
+				'function',
+			);
+			expect(typeof deprecatedApisEsm.createDeprecatedApiConfig).toBe('function');
+			expect(typeof reanimatedEsm.createReanimatedConfig).toBe('function');
+			expect(typeof semanticColorsEsm.createSemanticColorsConfig).toBe(
+				'function',
+			);
 		});
 	});
 });

--- a/packages/eslint-config-expo-magic/index.test.ts
+++ b/packages/eslint-config-expo-magic/index.test.ts
@@ -1499,7 +1499,7 @@ describe('eslint-config-expo-magic', () => {
 	describe('expo-magic plugin rules', () => {
 		RuleTester.describe = describe;
 		RuleTester.it = it;
-		RuleTester.itOnly = (it as { only?: typeof it }).only ?? it;
+		RuleTester.itOnly = it;
 
 		const ruleTester = new RuleTester({
 			languageOptions: {

--- a/packages/eslint-config-expo-magic/package.json
+++ b/packages/eslint-config-expo-magic/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "eslint-config-expo-magic",
-	"version": "2.6.0",
+	"version": "2.7.0",
 	"description": "ESLint flat config for Expo, React Native, and TypeScript projects",
 	"keywords": [
 		"eslint",
@@ -69,6 +69,16 @@
 			"require": "./app-guardrails.js",
 			"import": "./app-guardrails.mjs"
 		},
+		"./component-structure": {
+			"types": "./component-structure.d.ts",
+			"require": "./component-structure.js",
+			"import": "./component-structure.mjs"
+		},
+		"./deprecated-apis": {
+			"types": "./deprecated-apis.d.ts",
+			"require": "./deprecated-apis.js",
+			"import": "./deprecated-apis.mjs"
+		},
 		"./feature-boundaries": {
 			"types": "./feature-boundaries.d.ts",
 			"require": "./feature-boundaries.js",
@@ -88,6 +98,16 @@
 			"types": "./react-compiler.d.ts",
 			"require": "./react-compiler.js",
 			"import": "./react-compiler.mjs"
+		},
+		"./reanimated": {
+			"types": "./reanimated.d.ts",
+			"require": "./reanimated.js",
+			"import": "./reanimated.mjs"
+		},
+		"./semantic-colors": {
+			"types": "./semantic-colors.d.ts",
+			"require": "./semantic-colors.js",
+			"import": "./semantic-colors.mjs"
 		},
 		"./storybook": {
 			"types": "./storybook.d.ts",
@@ -118,6 +138,10 @@
 		"typed.mjs",
 		"app-guardrails.js",
 		"app-guardrails.mjs",
+		"component-structure.js",
+		"component-structure.mjs",
+		"deprecated-apis.js",
+		"deprecated-apis.mjs",
 		"feature-boundaries.js",
 		"feature-boundaries.mjs",
 		"native-ui.js",
@@ -126,6 +150,10 @@
 		"pr-guardrails.mjs",
 		"react-compiler.js",
 		"react-compiler.mjs",
+		"reanimated.js",
+		"reanimated.mjs",
+		"semantic-colors.js",
+		"semantic-colors.mjs",
 		"storybook.js",
 		"storybook.mjs",
 		"worklets.js",
@@ -136,19 +164,24 @@
 		"no-prettier.d.ts",
 		"typed.d.ts",
 		"app-guardrails.d.ts",
+		"component-structure.d.ts",
+		"deprecated-apis.d.ts",
 		"feature-boundaries.d.ts",
 		"native-ui.d.ts",
 		"pr-guardrails.d.ts",
 		"react-compiler.d.ts",
+		"reanimated.d.ts",
+		"semantic-colors.d.ts",
 		"storybook.d.ts",
 		"worklets.d.ts",
 		"README.md",
 		"bin/*.js",
-		"utils/*.js",
+		"utils/**/*.js",
 		".prettierrc.js"
 	],
 	"scripts": {
 		"test": "bun test",
+		"typecheck": "tsc -p tsconfig.types.json",
 		"prepublishOnly": "node ../../scripts/release-check.js",
 		"check-pm": "node check-pm.js",
 		"pack:dry-run": "bun pm pack --dry-run",

--- a/packages/eslint-config-expo-magic/react-compiler.d.ts
+++ b/packages/eslint-config-expo-magic/react-compiler.d.ts
@@ -1,17 +1,7 @@
 import type { Linter } from 'eslint';
 
-type RestrictedSyntaxSelector = {
-	selector: string;
-	message?: string;
-};
-
-type RestrictedSyntaxGroup = {
-	files: string[];
-	selectors: RestrictedSyntaxSelector[];
-};
-
 declare const reactCompilerConfig: Linter.Config[] & {
-	restrictedSyntaxGroups: RestrictedSyntaxGroup[];
+	rules: Record<string, Linter.RuleEntry>;
 };
 
 export = reactCompilerConfig;

--- a/packages/eslint-config-expo-magic/reanimated.d.ts
+++ b/packages/eslint-config-expo-magic/reanimated.d.ts
@@ -1,0 +1,30 @@
+import type { Linter } from 'eslint';
+
+type RestrictedSyntaxSelector = {
+	selector: string;
+	message?: string;
+};
+
+type RestrictedSyntaxGroup = {
+	files: string[];
+	selectors: RestrictedSyntaxSelector[];
+};
+
+type ReanimatedOptions = {
+	gestureHooks?: string[];
+	additionalGestureHooks?: string[];
+};
+
+declare const reanimatedConfig: Linter.Config[] & {
+	createReanimatedConfig(options?: ReanimatedOptions): Linter.Config[];
+	createRestrictedSyntaxGroups(
+		options?: ReanimatedOptions,
+	): RestrictedSyntaxGroup[];
+	restrictedSyntaxGroups: RestrictedSyntaxGroup[];
+};
+
+declare namespace reanimatedConfig {
+	export { ReanimatedOptions, RestrictedSyntaxGroup, RestrictedSyntaxSelector };
+}
+
+export = reanimatedConfig;

--- a/packages/eslint-config-expo-magic/reanimated.js
+++ b/packages/eslint-config-expo-magic/reanimated.js
@@ -1,0 +1,1 @@
+module.exports = require('./utils/reanimated.js');

--- a/packages/eslint-config-expo-magic/reanimated.mjs
+++ b/packages/eslint-config-expo-magic/reanimated.mjs
@@ -1,0 +1,10 @@
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const reanimated = require('./reanimated.js');
+
+export default reanimated;
+export const createReanimatedConfig = reanimated.createReanimatedConfig;
+export const createRestrictedSyntaxGroups =
+	reanimated.createRestrictedSyntaxGroups;
+export const restrictedSyntaxGroups = reanimated.restrictedSyntaxGroups;

--- a/packages/eslint-config-expo-magic/semantic-colors.d.ts
+++ b/packages/eslint-config-expo-magic/semantic-colors.d.ts
@@ -1,0 +1,37 @@
+import type { Linter } from 'eslint';
+
+type RestrictedSyntaxSelector = {
+	selector: string;
+	message?: string;
+};
+
+type RestrictedSyntaxGroup = {
+	files: string[];
+	selectors: RestrictedSyntaxSelector[];
+};
+
+type SemanticColorsOptions = {
+	tokenModule?: string;
+	importName?: string;
+	flagDirectAccess?: boolean;
+	allowFiles?: string[];
+};
+
+declare const semanticColorsConfig: Linter.Config[] & {
+	createSemanticColorsConfig(options?: SemanticColorsOptions): Linter.Config[];
+	createRestrictedSyntaxGroups(
+		options?: SemanticColorsOptions,
+	): RestrictedSyntaxGroup[];
+	createAllowConfig(options?: SemanticColorsOptions): Linter.Config[];
+	restrictedSyntaxGroups: RestrictedSyntaxGroup[];
+};
+
+declare namespace semanticColorsConfig {
+	export {
+		RestrictedSyntaxGroup,
+		RestrictedSyntaxSelector,
+		SemanticColorsOptions,
+	};
+}
+
+export = semanticColorsConfig;

--- a/packages/eslint-config-expo-magic/semantic-colors.js
+++ b/packages/eslint-config-expo-magic/semantic-colors.js
@@ -1,0 +1,1 @@
+module.exports = require('./utils/semantic-colors.js');

--- a/packages/eslint-config-expo-magic/semantic-colors.mjs
+++ b/packages/eslint-config-expo-magic/semantic-colors.mjs
@@ -1,0 +1,12 @@
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const semanticColors = require('./semantic-colors.js');
+
+export default semanticColors;
+export const createSemanticColorsConfig =
+	semanticColors.createSemanticColorsConfig;
+export const createRestrictedSyntaxGroups =
+	semanticColors.createRestrictedSyntaxGroups;
+export const createAllowConfig = semanticColors.createAllowConfig;
+export const restrictedSyntaxGroups = semanticColors.restrictedSyntaxGroups;

--- a/packages/eslint-config-expo-magic/tsconfig.types.json
+++ b/packages/eslint-config-expo-magic/tsconfig.types.json
@@ -1,0 +1,14 @@
+{
+	"compilerOptions": {
+		"lib": ["ESNext", "DOM"],
+		"target": "ESNext",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"jsx": "react-jsx",
+		"strict": true,
+		"skipLibCheck": true,
+		"noEmit": true,
+		"types": []
+	},
+	"include": ["type-tests.ts"]
+}

--- a/packages/eslint-config-expo-magic/type-tests.ts
+++ b/packages/eslint-config-expo-magic/type-tests.ts
@@ -1,0 +1,58 @@
+import type { Linter } from 'eslint';
+
+type Magic = typeof import('./index');
+type Opts = import('./index').CreateConfigOptions;
+
+declare const magic: Magic;
+
+const options: Opts = {
+	preset: 'base',
+	prettier: false,
+	appGuardrails: { queryHookPattern: '^useFetch[A-Z]' },
+	componentStructure: { propsTypePattern: 'Props$' },
+	deprecatedApis: true,
+	inlineStyles: 'warn',
+	reanimated: { additionalGestureHooks: ['useFlingGesture'] },
+	semanticColors: { tokenModule: 'theme/palette', importName: 'palette' },
+};
+
+const baseResult: Linter.Config[] = magic.createConfig(options);
+const reResult: Linter.Config[] = magic.createReanimatedConfig({
+	gestureHooks: ['useX'],
+});
+const compilerRules: Record<string, Linter.RuleEntry> =
+	magic.reactCompiler.rules;
+void baseResult;
+void reResult;
+void compilerRules;
+
+type ReanimatedModule = typeof import('./reanimated');
+type DeprecatedModule = typeof import('./deprecated-apis');
+type StructureModule = typeof import('./component-structure');
+type ColorsModule = typeof import('./semantic-colors');
+
+declare const reanimated: ReanimatedModule;
+declare const deprecated: DeprecatedModule;
+declare const structure: StructureModule;
+declare const colors: ColorsModule;
+
+const reanimatedResult: Linter.Config[] = reanimated.createReanimatedConfig();
+const deprecatedResult: Linter.Config[] =
+	deprecated.createDeprecatedApiConfig();
+const structureResult: Linter.Config[] =
+	structure.createComponentStructureConfig();
+const colorsResult: Linter.Config[] = colors.createSemanticColorsConfig();
+void reanimatedResult;
+void deprecatedResult;
+void structureResult;
+void colorsResult;
+
+// @ts-expect-error preset only accepts 'base' | 'default'
+const badPreset: Opts = { preset: 'ultra' };
+// @ts-expect-error unknown option keys are rejected
+const badKey: Opts = { unknownOption: true };
+// @ts-expect-error gestureHooks must be a string array
+const badReanimated: Opts = { reanimated: { gestureHooks: [1] } };
+void badPreset;
+void badKey;
+void badReanimated;

--- a/packages/eslint-config-expo-magic/utils/app-guardrails.js
+++ b/packages/eslint-config-expo-magic/utils/app-guardrails.js
@@ -17,35 +17,43 @@ const testFiles = [
 	'**/*.spec.tsx',
 ];
 
-const restrictedSyntaxGroups = [
-	{
-		files: typeScriptFiles,
-		selectors: [
-			{
-				selector: 'TSAsExpression > TSAsExpression',
-				message:
-					'Avoid double type assertions. Prefer proper type guards or generic typing.',
-			},
-			{
-				selector:
-					'TSTypeReference[typeName.name="ReturnType"] TSTypeQuery > Identifier[name=/^useGet[A-Z]/]',
-				message:
-					'Avoid `ReturnType<typeof useGet...>` with selector-capable query hooks. Use domain types or shared query-result helpers.',
-			},
-		],
-	},
-	{
-		files: testFiles,
-		selectors: [
-			{
-				selector:
-					'CallExpression[callee.property.name="toMatchSnapshot"], CallExpression[callee.name="toMatchSnapshot"]',
-				message:
-					'Prefer focused assertions over snapshots for production app regressions.',
-			},
-		],
-	},
-];
+const DEFAULT_QUERY_HOOK_PATTERN = '^useGet[A-Z]';
+
+function createRestrictedSyntaxGroups(options = {}) {
+	const queryHookPattern =
+		options.queryHookPattern ?? DEFAULT_QUERY_HOOK_PATTERN;
+
+	return [
+		{
+			files: typeScriptFiles,
+			selectors: [
+				{
+					selector: 'TSAsExpression > TSAsExpression',
+					message:
+						'Avoid double type assertions. Prefer proper type guards or generic typing.',
+				},
+				{
+					selector: `TSTypeReference[typeName.name="ReturnType"] TSTypeQuery > Identifier[name=/${queryHookPattern}/]`,
+					message:
+						'Avoid `ReturnType<typeof useGet...>` with selector-capable query hooks. Use domain types or shared query-result helpers.',
+				},
+			],
+		},
+		{
+			files: testFiles,
+			selectors: [
+				{
+					selector:
+						'CallExpression[callee.property.name="toMatchSnapshot"], CallExpression[callee.name="toMatchSnapshot"]',
+					message:
+						'Prefer focused assertions over snapshots for production app regressions.',
+				},
+			],
+		},
+	];
+}
+
+const restrictedSyntaxGroups = createRestrictedSyntaxGroups();
 
 const base = [
 	{
@@ -77,8 +85,17 @@ const base = [
 	},
 ];
 
-const config = [...base, ...createRestrictedSyntaxConfigs(restrictedSyntaxGroups)];
+function createAppGuardrailsConfig(options = {}) {
+	return [
+		...base,
+		...createRestrictedSyntaxConfigs(createRestrictedSyntaxGroups(options)),
+	];
+}
+
+const config = createAppGuardrailsConfig();
 
 module.exports = config;
 module.exports.base = base;
+module.exports.createAppGuardrailsConfig = createAppGuardrailsConfig;
+module.exports.createRestrictedSyntaxGroups = createRestrictedSyntaxGroups;
 module.exports.restrictedSyntaxGroups = restrictedSyntaxGroups;

--- a/packages/eslint-config-expo-magic/utils/app.js
+++ b/packages/eslint-config-expo-magic/utils/app.js
@@ -1,5 +1,7 @@
 /** @type {import('eslint').Linter.Config[]} */
 // Rationale: https://github.com/JoaoPauloCMarra/eslint-config-expo-magic/blob/main/RULES.md#mobile-first-infrastructure
+const { baseRestrictedImports } = require('./restricted-imports.js');
+
 module.exports = [
 	{
 		rules: {
@@ -7,14 +9,7 @@ module.exports = [
 			'no-restricted-imports': [
 				'error',
 				{
-					paths: [
-						{
-							name: 'react-native',
-							importNames: ['SafeAreaView'],
-							message:
-								"Use 'SafeAreaView' from 'react-native-safe-area-context' instead.",
-						},
-					],
+					paths: [...baseRestrictedImports],
 				},
 			],
 			'no-unused-vars': [

--- a/packages/eslint-config-expo-magic/utils/component-structure.js
+++ b/packages/eslint-config-expo-magic/utils/component-structure.js
@@ -1,0 +1,41 @@
+const plugin = require('./plugin/index.js');
+
+const propTypeFiles = ['**/*.ts', '**/*.tsx'];
+const componentFiles = ['**/*.tsx'];
+
+function createComponentStructureConfig(options = {}) {
+	const propsTypePattern = options.propsTypePattern;
+	const propsOrderRule = propsTypePattern
+		? ['warn', { pattern: propsTypePattern }]
+		: ['warn'];
+
+	return [
+		{
+			files: propTypeFiles,
+			plugins: {
+				'expo-magic': plugin,
+			},
+			rules: {
+				'expo-magic/no-inline-props': 'error',
+				'expo-magic/props-type-order': propsOrderRule,
+			},
+		},
+		{
+			files: componentFiles,
+			plugins: {
+				'expo-magic': plugin,
+			},
+			rules: {
+				'expo-magic/default-export-placement': 'error',
+				'expo-magic/require-children-usage': 'warn',
+			},
+		},
+	];
+}
+
+const recommended = createComponentStructureConfig();
+
+module.exports = recommended;
+module.exports.createComponentStructureConfig = createComponentStructureConfig;
+module.exports.plugin = plugin;
+module.exports.recommended = recommended;

--- a/packages/eslint-config-expo-magic/utils/deprecated-apis.js
+++ b/packages/eslint-config-expo-magic/utils/deprecated-apis.js
@@ -1,0 +1,68 @@
+const typeScriptFiles = [
+	'**/*.ts',
+	'**/*.tsx',
+	'**/*.mts',
+	'**/*.cts',
+	'**/*.d.ts',
+	'**/*.d.mts',
+	'**/*.d.cts',
+];
+
+const defaultRestrictedTypes = {
+	MutableRefObject: {
+		message:
+			'`MutableRefObject` is removed from React 19 typings. Use `RefObject` instead.',
+		fixWith: 'RefObject',
+	},
+};
+
+const defaultRestrictedProperties = [
+	{
+		object: 'StyleSheet',
+		property: 'absoluteFillObject',
+		message:
+			'`StyleSheet.absoluteFillObject` is deprecated. Use `StyleSheet.absoluteFill`.',
+	},
+	{
+		object: 'AccessibilityInfo',
+		property: 'setAccessibilityFocus',
+		message:
+			'`AccessibilityInfo.setAccessibilityFocus` is deprecated. Use `AccessibilityInfo.sendAccessibilityEvent`.',
+	},
+];
+
+function createDeprecatedApiConfig(options = {}) {
+	const restrictedTypes = {
+		...defaultRestrictedTypes,
+		...(options.additionalRestrictedTypes ?? {}),
+	};
+	const restrictedProperties = [
+		...defaultRestrictedProperties,
+		...(options.additionalRestrictedProperties ?? []),
+	];
+
+	return [
+		{
+			rules: {
+				'no-restricted-properties': ['error', ...restrictedProperties],
+			},
+		},
+		{
+			files: typeScriptFiles,
+			rules: {
+				'@typescript-eslint/no-restricted-types': [
+					'error',
+					{ types: restrictedTypes },
+				],
+			},
+		},
+	];
+}
+
+const recommended = createDeprecatedApiConfig();
+
+module.exports = recommended;
+module.exports.createDeprecatedApiConfig = createDeprecatedApiConfig;
+module.exports.defaultRestrictedProperties = defaultRestrictedProperties;
+module.exports.defaultRestrictedTypes = defaultRestrictedTypes;
+module.exports.recommended = recommended;

--- a/packages/eslint-config-expo-magic/utils/native-ui.js
+++ b/packages/eslint-config-expo-magic/utils/native-ui.js
@@ -1,9 +1,7 @@
+const { baseRestrictedImports } = require('./restricted-imports.js');
+
 const defaultRestrictions = [
-	{
-		name: 'react-native',
-		importNames: ['SafeAreaView'],
-		message: "Use 'SafeAreaView' from 'react-native-safe-area-context' instead.",
-	},
+	...baseRestrictedImports,
 	{
 		name: 'react-native',
 		importNames: ['Button'],

--- a/packages/eslint-config-expo-magic/utils/plugin/index.js
+++ b/packages/eslint-config-expo-magic/utils/plugin/index.js
@@ -1,0 +1,18 @@
+const defaultExportPlacement = require('./rules/default-export-placement.js');
+const noInlineProps = require('./rules/no-inline-props.js');
+const propsTypeOrder = require('./rules/props-type-order.js');
+const requireChildrenUsage = require('./rules/require-children-usage.js');
+
+const plugin = {
+	meta: {
+		name: 'eslint-plugin-expo-magic',
+	},
+	rules: {
+		'default-export-placement': defaultExportPlacement,
+		'no-inline-props': noInlineProps,
+		'props-type-order': propsTypeOrder,
+		'require-children-usage': requireChildrenUsage,
+	},
+};
+
+module.exports = plugin;

--- a/packages/eslint-config-expo-magic/utils/plugin/rules/default-export-placement.js
+++ b/packages/eslint-config-expo-magic/utils/plugin/rules/default-export-placement.js
@@ -1,0 +1,83 @@
+function getDeclaredNames(statement) {
+	if (!statement) {
+		return [];
+	}
+
+	let node = statement;
+	if (node.type === 'ExportNamedDeclaration' && node.declaration) {
+		node = node.declaration;
+	}
+
+	if (
+		(node.type === 'FunctionDeclaration' || node.type === 'ClassDeclaration') &&
+		node.id
+	) {
+		return [node.id.name];
+	}
+
+	if (node.type === 'VariableDeclaration') {
+		return node.declarations
+			.filter((declaration) => declaration.id.type === 'Identifier')
+			.map((declaration) => declaration.id.name);
+	}
+
+	return [];
+}
+
+module.exports = {
+	meta: {
+		type: 'suggestion',
+		docs: {
+			description:
+				'Require `export default Component;` to be placed immediately after the exported component declaration.',
+		},
+		schema: [],
+		messages: {
+			placement:
+				'`export default {{name}};` should be placed immediately after the `{{name}}` declaration, before helpers, styles, or child components.',
+		},
+	},
+	create(context) {
+		return {
+			Program(node) {
+				const body = node.body;
+				const declaredAt = new Map();
+
+				body.forEach((statement, index) => {
+					for (const name of getDeclaredNames(statement)) {
+						if (!declaredAt.has(name)) {
+							declaredAt.set(name, index);
+						}
+					}
+				});
+
+				body.forEach((statement, index) => {
+					if (statement.type !== 'ExportDefaultDeclaration') {
+						return;
+					}
+
+					const declaration = statement.declaration;
+					if (!declaration || declaration.type !== 'Identifier') {
+						return;
+					}
+
+					const name = declaration.name;
+					if (!/^[A-Z]/.test(name) || !declaredAt.has(name)) {
+						return;
+					}
+
+					const previous = body[index - 1];
+					if (previous && getDeclaredNames(previous).includes(name)) {
+						return;
+					}
+
+					context.report({
+						node: statement,
+						messageId: 'placement',
+						data: { name },
+					});
+				});
+			},
+		};
+	},
+};

--- a/packages/eslint-config-expo-magic/utils/plugin/rules/no-inline-props.js
+++ b/packages/eslint-config-expo-magic/utils/plugin/rules/no-inline-props.js
@@ -1,0 +1,38 @@
+function hasInlineObjectType(param) {
+	const annotation = param.typeAnnotation?.typeAnnotation;
+	return annotation?.type === 'TSTypeLiteral';
+}
+
+module.exports = {
+	meta: {
+		type: 'suggestion',
+		docs: {
+			description:
+				'Disallow inline object types for a `props` parameter; declare a named `Props` type alias instead.',
+		},
+		schema: [],
+		messages: {
+			inline:
+				'Declare a named `type ...Props` alias for component props instead of an inline object type.',
+		},
+	},
+	create(context) {
+		function check(node) {
+			for (const param of node.params) {
+				if (
+					param.type === 'Identifier' &&
+					param.name === 'props' &&
+					hasInlineObjectType(param)
+				) {
+					context.report({ node: param, messageId: 'inline' });
+				}
+			}
+		}
+
+		return {
+			FunctionDeclaration: check,
+			FunctionExpression: check,
+			ArrowFunctionExpression: check,
+		};
+	},
+};

--- a/packages/eslint-config-expo-magic/utils/plugin/rules/props-type-order.js
+++ b/packages/eslint-config-expo-magic/utils/plugin/rules/props-type-order.js
@@ -1,0 +1,139 @@
+const DEFAULT_PATTERN = /Props$/;
+
+function getPropertyName(member) {
+	const key = member.key;
+	if (!key) {
+		return null;
+	}
+
+	if (key.type === 'Identifier') {
+		return key.name;
+	}
+
+	if (key.type === 'Literal' && typeof key.value === 'string') {
+		return key.value;
+	}
+
+	return null;
+}
+
+function isFunctionType(typeNode) {
+	if (!typeNode) {
+		return false;
+	}
+
+	if (typeNode.type === 'TSFunctionType') {
+		return true;
+	}
+
+	if (typeNode.type === 'TSUnionType') {
+		return typeNode.types.some(isFunctionType);
+	}
+
+	if (typeNode.type === 'TSTypeReference') {
+		const typeName = typeNode.typeName;
+		const identifier =
+			typeName?.type === 'Identifier'
+				? typeName.name
+				: typeName?.type === 'TSQualifiedName'
+					? typeName.right.name
+					: '';
+
+		return identifier === 'VoidFunction' || /Handler$/.test(identifier);
+	}
+
+	return false;
+}
+
+function rankMember(member) {
+	if (isFunctionType(member.typeAnnotation?.typeAnnotation)) {
+		return 2;
+	}
+
+	return member.optional ? 1 : 0;
+}
+
+function getExpectedOrder(members) {
+	const decorated = members.map((member, index) => ({
+		index,
+		member,
+		name: (getPropertyName(member) ?? '').toLowerCase(),
+		rank: rankMember(member),
+	}));
+	const sorted = [...decorated].sort((left, right) => {
+		if (left.rank !== right.rank) {
+			return left.rank - right.rank;
+		}
+
+		return left.name.localeCompare(right.name);
+	});
+	const alreadyOrdered = sorted.every((entry, index) => entry.index === index);
+
+	return alreadyOrdered ? null : sorted.map((entry) => entry.member);
+}
+
+module.exports = {
+	meta: {
+		type: 'suggestion',
+		docs: {
+			description:
+				'Enforce required, optional, then function prop ordering in component prop type aliases, alphabetized within each group.',
+		},
+		schema: [
+			{
+				type: 'object',
+				properties: {
+					pattern: { type: 'string' },
+				},
+				additionalProperties: false,
+			},
+		],
+		messages: {
+			order:
+				'`{{name}}` members should be ordered required, optional, then function props, alphabetized within each group. Expected: {{expected}}.',
+		},
+	},
+	create(context) {
+		const options = context.options[0] ?? {};
+		const pattern = options.pattern
+			? new RegExp(options.pattern)
+			: DEFAULT_PATTERN;
+
+		return {
+			TSTypeAliasDeclaration(node) {
+				if (!pattern.test(node.id.name)) {
+					return;
+				}
+
+				const typeNode = node.typeAnnotation;
+				if (!typeNode || typeNode.type !== 'TSTypeLiteral') {
+					return;
+				}
+
+				const members = typeNode.members;
+				if (
+					members.length < 2 ||
+					!members.every((member) => member.type === 'TSPropertySignature') ||
+					members.some((member) => getPropertyName(member) === null)
+				) {
+					return;
+				}
+
+				const expectedOrder = getExpectedOrder(members);
+				if (!expectedOrder) {
+					return;
+				}
+
+				const expectedNames = expectedOrder
+					.map((member) => getPropertyName(member))
+					.join(', ');
+
+				context.report({
+					node: node.id,
+					messageId: 'order',
+					data: { name: node.id.name, expected: expectedNames },
+				});
+			},
+		};
+	},
+};

--- a/packages/eslint-config-expo-magic/utils/plugin/rules/require-children-usage.js
+++ b/packages/eslint-config-expo-magic/utils/plugin/rules/require-children-usage.js
@@ -1,0 +1,87 @@
+function getReferenceName(typeName) {
+	if (!typeName) {
+		return '';
+	}
+
+	if (typeName.type === 'Identifier') {
+		return typeName.name;
+	}
+
+	if (typeName.type === 'TSQualifiedName') {
+		return typeName.right.name;
+	}
+
+	return '';
+}
+
+function isDeclarationKey(node) {
+	const parent = node.parent;
+	return (
+		parent?.type === 'TSPropertySignature' &&
+		parent.key === node &&
+		!parent.computed
+	);
+}
+
+module.exports = {
+	meta: {
+		type: 'suggestion',
+		docs: {
+			description:
+				'Disallow declaring a `children` prop that the component never renders.',
+		},
+		schema: [],
+		messages: {
+			unused:
+				'`children` is declared but never rendered. Reserve children for components that render arbitrary caller content.',
+		},
+	},
+	create(context) {
+		let declarationNode = null;
+		let usesChildren = false;
+
+		function markDeclaration(node) {
+			if (!declarationNode) {
+				declarationNode = node;
+			}
+		}
+
+		return {
+			TSPropertySignature(node) {
+				if (
+					node.key?.type === 'Identifier' &&
+					node.key.name === 'children' &&
+					!node.computed
+				) {
+					markDeclaration(node);
+				}
+			},
+			TSTypeReference(node) {
+				if (getReferenceName(node.typeName) === 'PropsWithChildren') {
+					markDeclaration(node);
+				}
+			},
+			Identifier(node) {
+				if (node.name === 'children' && !isDeclarationKey(node)) {
+					usesChildren = true;
+				}
+			},
+			JSXSpreadAttribute() {
+				usesChildren = true;
+			},
+			SpreadElement(node) {
+				if (
+					node.argument?.type === 'Identifier' &&
+					node.argument.name === 'props'
+				) {
+					usesChildren = true;
+				}
+			},
+			'Program:exit'() {
+				if (declarationNode && !usesChildren) {
+					context.report({ node: declarationNode, messageId: 'unused' });
+				}
+			},
+		};
+	},
+};

--- a/packages/eslint-config-expo-magic/utils/react-compiler.js
+++ b/packages/eslint-config-expo-magic/utils/react-compiler.js
@@ -1,29 +1,24 @@
-const { createRestrictedSyntaxConfigs } = require('./restricted-syntax.js');
+const { fixupPluginRules } = require('@eslint/compat');
+const pluginReactHooks = require('eslint-plugin-react-hooks');
 
-const restrictedSyntaxGroups = [
+const rules = {
+	'react-hooks/incompatible-library': 'error',
+	'react-hooks/unsupported-syntax': 'error',
+	'react-hooks/immutability': 'error',
+	'react-hooks/purity': 'error',
+	'react-hooks/preserve-manual-memoization': 'error',
+	'react-hooks/set-state-in-render': 'error',
+	'react-hooks/static-components': 'error',
+};
+
+const config = [
 	{
-		files: ['**/*.tsx'],
-		selectors: [
-			{
-				selector: 'TryStatement[finalizer!=null]',
-				message:
-					'React Compiler does not support try/finally in component or hook render scope. Use Promise.finally or explicit cleanup paths.',
-			},
-			{
-				selector: 'TryStatement ThrowStatement',
-				message:
-					'React Compiler does not support throw inside try/catch in component or hook render scope. Prefer early returns and callback/onError handling.',
-			},
-			{
-				selector: 'TryStatement ChainExpression',
-				message:
-					'React Compiler can fail on optional chaining inside try/catch render scope. Resolve optional values before entering try/catch.',
-			},
-		],
+		plugins: {
+			'react-hooks': fixupPluginRules(pluginReactHooks),
+		},
+		rules: { ...rules },
 	},
 ];
 
-const config = createRestrictedSyntaxConfigs(restrictedSyntaxGroups);
-
 module.exports = config;
-module.exports.restrictedSyntaxGroups = restrictedSyntaxGroups;
+module.exports.rules = rules;

--- a/packages/eslint-config-expo-magic/utils/reanimated.js
+++ b/packages/eslint-config-expo-magic/utils/reanimated.js
@@ -1,0 +1,66 @@
+const { createRestrictedSyntaxConfigs } = require('./restricted-syntax.js');
+
+const typeScriptFiles = ['**/*.ts', '**/*.tsx'];
+
+const DEFAULT_GESTURE_HOOKS = ['usePanGesture'];
+const ANIMATED_HOOKS = [
+	'useAnimatedStyle',
+	'useAnimatedReaction',
+	'useDerivedValue',
+	'useAnimatedProps',
+];
+
+function createRestrictedSyntaxGroups(options = {}) {
+	const gestureHooks = [
+		...(options.gestureHooks ?? DEFAULT_GESTURE_HOOKS),
+		...(options.additionalGestureHooks ?? []),
+	];
+
+	const selectors = [
+		{
+			selector:
+				'CallExpression[callee.name="useSharedValue"] > CallExpression[callee.property.name="get"]',
+			message:
+				'Do not read a shared value with `.get()` inside `useSharedValue(...)`. Initialize from a plain value and sync in an effect or worklet reaction.',
+		},
+		{
+			selector:
+				'CallExpression[callee.name="useSharedValue"] > MemberExpression[property.name="value"]',
+			message:
+				'Do not read a shared value with `.value` inside `useSharedValue(...)`. Initialize from a plain value and sync in an effect or worklet reaction.',
+		},
+		{
+			selector: `CallExpression[callee.name=/^(${ANIMATED_HOOKS.join('|')})$/] CallExpression[callee.property.name="get"]`,
+			message:
+				'Use `.value`, not `.get()`, when reading shared values inside Reanimated worklet hooks.',
+		},
+	];
+
+	if (gestureHooks.length > 0) {
+		selectors.push({
+			selector: `CallExpression[callee.name=/^(${gestureHooks.join('|')})$/] > ObjectExpression`,
+			message:
+				'Memoize gesture config before passing it to RNGH gesture hooks so Reanimated does not rebuild worklet closures on every render.',
+		});
+	}
+
+	return [
+		{
+			files: typeScriptFiles,
+			selectors,
+		},
+	];
+}
+
+const restrictedSyntaxGroups = createRestrictedSyntaxGroups();
+
+function createReanimatedConfig(options = {}) {
+	return createRestrictedSyntaxConfigs(createRestrictedSyntaxGroups(options));
+}
+
+const config = createReanimatedConfig();
+
+module.exports = config;
+module.exports.createReanimatedConfig = createReanimatedConfig;
+module.exports.createRestrictedSyntaxGroups = createRestrictedSyntaxGroups;
+module.exports.restrictedSyntaxGroups = restrictedSyntaxGroups;

--- a/packages/eslint-config-expo-magic/utils/restricted-imports.js
+++ b/packages/eslint-config-expo-magic/utils/restricted-imports.js
@@ -1,0 +1,12 @@
+const baseRestrictedImports = [
+	{
+		name: 'react-native',
+		importNames: ['SafeAreaView'],
+		message:
+			"Use 'SafeAreaView' from 'react-native-safe-area-context' instead.",
+	},
+];
+
+module.exports = {
+	baseRestrictedImports,
+};

--- a/packages/eslint-config-expo-magic/utils/semantic-colors.js
+++ b/packages/eslint-config-expo-magic/utils/semantic-colors.js
@@ -1,0 +1,86 @@
+const { createRestrictedSyntaxConfigs } = require('./restricted-syntax.js');
+
+const typeScriptFiles = ['**/*.ts', '**/*.tsx'];
+
+const RAW_COLOR_SELECTOR =
+	'Literal[value=/^(#([0-9a-fA-F]{3,8})|rgba?\\([^)]*\\)|hsla?\\([^)]*\\))$/]';
+
+function buildImportSourceRegex(tokenModule) {
+	const escaped = tokenModule
+		.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+		.replace(/\//g, '\\/');
+
+	return `(^|\\/)${escaped}$`;
+}
+
+function createRestrictedSyntaxGroups(options = {}) {
+	const tokenModule = options.tokenModule ?? 'uikit/tokens/colors';
+	const importName = options.importName ?? 'colors';
+	const flagDirectAccess = options.flagDirectAccess ?? true;
+	const importSourceRegex = buildImportSourceRegex(tokenModule);
+
+	const selectors = [
+		{
+			selector: RAW_COLOR_SELECTOR,
+			message:
+				'Do not use raw color literals. Add the color to the token file and consume it through `semanticColors`.',
+		},
+		{
+			selector: `ImportDeclaration[source.value=/${importSourceRegex}/] > ImportSpecifier[imported.name="${importName}"]`,
+			message:
+				'Do not import the raw color token map. Consume colors through `semanticColors`.',
+		},
+	];
+
+	if (flagDirectAccess) {
+		selectors.push({
+			selector: `MemberExpression[object.name="${importName}"]`,
+			message:
+				'Do not access the raw color token map directly. Consume colors through `semanticColors`.',
+		});
+	}
+
+	return [
+		{
+			files: typeScriptFiles,
+			selectors,
+		},
+	];
+}
+
+function getAllowFiles(options = {}) {
+	const tokenModule = options.tokenModule ?? 'uikit/tokens/colors';
+	return options.allowFiles ?? [`**/${tokenModule}.{ts,tsx}`];
+}
+
+function createAllowConfig(options = {}) {
+	const allowFiles = getAllowFiles(options);
+	if (allowFiles.length === 0) {
+		return [];
+	}
+
+	return [
+		{
+			files: allowFiles,
+			rules: {
+				'no-restricted-syntax': 'off',
+			},
+		},
+	];
+}
+
+function createSemanticColorsConfig(options = {}) {
+	return [
+		...createRestrictedSyntaxConfigs(createRestrictedSyntaxGroups(options)),
+		...createAllowConfig(options),
+	];
+}
+
+const restrictedSyntaxGroups = createRestrictedSyntaxGroups();
+const config = createSemanticColorsConfig();
+
+module.exports = config;
+module.exports.createAllowConfig = createAllowConfig;
+module.exports.createRestrictedSyntaxGroups = createRestrictedSyntaxGroups;
+module.exports.createSemanticColorsConfig = createSemanticColorsConfig;
+module.exports.restrictedSyntaxGroups = restrictedSyntaxGroups;

--- a/scripts/lib/config-report.js
+++ b/scripts/lib/config-report.js
@@ -90,6 +90,14 @@ function createConfigReport() {
 			'appGuardrails',
 			magicConfig.appGuardrails,
 		),
+		componentStructure: createPresetSummary(
+			'componentStructure',
+			magicConfig.componentStructure,
+		),
+		deprecatedApis: createPresetSummary(
+			'deprecatedApis',
+			magicConfig.deprecatedApis,
+		),
 		featureBoundaries: createPresetSummary(
 			'featureBoundaries',
 			magicConfig.featureBoundaries,
@@ -99,14 +107,24 @@ function createConfigReport() {
 			'reactCompiler',
 			magicConfig.reactCompiler,
 		),
+		reanimated: createPresetSummary('reanimated', magicConfig.reanimated),
+		semanticColors: createPresetSummary(
+			'semanticColors',
+			magicConfig.semanticColors,
+		),
 		storybook: createPresetSummary('storybook', magicConfig.storybook),
 		worklets: createPresetSummary('worklets', magicConfig.worklets),
 		productionApp: createPresetSummary(
 			'productionApp',
 			magicConfig.createConfig({
 				appGuardrails: true,
+				componentStructure: true,
+				deprecatedApis: true,
+				inlineStyles: true,
 				nativeUi: true,
 				reactCompiler: true,
+				reanimated: true,
+				semanticColors: true,
 				storybook: true,
 				worklets: true,
 			}),

--- a/scripts/smoke-packed-consumer.js
+++ b/scripts/smoke-packed-consumer.js
@@ -244,24 +244,31 @@ function writeFixtureFiles(tempProjectDir) {
 	fs.writeFileSync(
 		path.join(tempProjectDir, 'hardening-smoke.tsx'),
 		[
-			"import { Button } from 'react-native';",
+			"import { Button, StyleSheet } from 'react-native';",
 			'',
 			'declare const value: unknown;',
+			'declare const shared: { value: number };',
 			'declare function useGetPeople(): { data: string[] };',
+			'declare function useSharedValue<T>(v: T): { value: T };',
+			'declare function usePanGesture(cfg: object): object;',
 			'declare function scheduleOnRN(callback: () => void): void;',
 			'',
 			'type QueryResult = ReturnType<typeof useGetPeople>;',
 			'const unsafeValue = value as unknown as string;',
 			'const queryResult = {} as QueryResult;',
+			'const fill = StyleSheet.absoluteFillObject;',
+			"const brand = '#ff0000';",
 			'',
 			'export function HardeningSmoke() {',
-			'\ttry {',
-			'\t\tvalue?.toString();',
-			'\t} finally {',
-			'\t\tscheduleOnRN(() => {});',
-			'\t}',
+			'\tconst animated = useSharedValue(shared.value);',
+			'\tconst gesture = usePanGesture({ onStart: () => {} });',
+			'\tscheduleOnRN(() => {});',
 			'',
-			'\treturn <Button title={`${unsafeValue}:${queryResult.data.length}`} />;',
+			'\treturn (',
+			'\t\t<Button',
+			'\t\t\ttitle={`${unsafeValue}:${queryResult.data.length}:${animated.value}:${brand}:${String(fill)}:${String(gesture)}`}',
+			'\t\t/>',
+			'\t);',
 			'}',
 			'',
 		].join('\n'),
@@ -326,8 +333,13 @@ function writeFixtureFiles(tempProjectDir) {
 			'\tprettier: false,',
 			'\ttesting: false,',
 			'\tappGuardrails: true,',
+			'\tcomponentStructure: true,',
+			'\tdeprecatedApis: true,',
+			'\tinlineStyles: true,',
 			'\tnativeUi: true,',
 			'\treactCompiler: true,',
+			'\treanimated: true,',
+			'\tsemanticColors: true,',
 			'\tstorybook: true,',
 			'\tworklets: true,',
 			'});',
@@ -483,9 +495,16 @@ function validateLane(tempProjectDir) {
 	if (
 		hardeningMessages.filter(
 			(message) => message.ruleId === 'no-restricted-syntax',
-		).length < 4
+		).length < 6
 	) {
 		throw new Error('Hardening config did not compose no-restricted-syntax rules.');
+	}
+	if (
+		!hardeningMessages.some(
+			(message) => message.ruleId === 'no-restricted-properties',
+		)
+	) {
+		throw new Error('Hardening config did not compose deprecated-api rules.');
 	}
 
 	const storyMessages = runLint(


### PR DESCRIPTION
# Changes

Opt-in hardening layers (all backward compatible — `default`/`strict`/`typed`/`no-prettier` presets are unchanged):

- **`reanimated`** (`createConfig({ reanimated: true })` / `eslint-config-expo-magic/reanimated`) — flags shared-value reads in `useSharedValue(...)` initializers, `.get()` inside `useAnimatedStyle`/`useAnimatedReaction`/`useDerivedValue`/`useAnimatedProps`, and inline gesture config passed to RNGH gesture hooks. Configurable via `gestureHooks` / `additionalGestureHooks`.
- **`deprecatedApis`** (`createConfig({ deprecatedApis: true })` / `eslint-config-expo-magic/deprecated-apis`) — flags `MutableRefObject`, `StyleSheet.absoluteFillObject`, and `AccessibilityInfo.setAccessibilityFocus`.
- **`componentStructure`** (`createConfig({ componentStructure: true })` / `eslint-config-expo-magic/component-structure`) — bundled `expo-magic` plugin with `props-type-order`, `default-export-placement`, `no-inline-props`, and `require-children-usage`. Configurable via `propsTypePattern`.
- **`semanticColors`** (`createConfig({ semanticColors: true })` / `eslint-config-expo-magic/semantic-colors`) — flags raw color literals and direct token access. Configurable `tokenModule` / `importName` / `flagDirectAccess` / `allowFiles`.
- **`inlineStyles` option** — enables `react-native/no-inline-styles`.
- **Configurable `appGuardrails`** (`{ queryHookPattern }`) and new factories: `createAppGuardrailsConfig`, `createComponentStructureConfig`, `createDeprecatedApiConfig`, `createReanimatedConfig`, `createSemanticColorsConfig`.

Behavior changes:

- **`reactCompiler`** now promotes the React Compiler diagnostics shipped in `eslint-plugin-react-hooks` v7 (`unsupported-syntax`, `incompatible-library`, `immutability`, `purity`, `preserve-manual-memoization`, `set-state-in-render`, `static-components`) to `error`, replacing the previous `no-restricted-syntax` heuristics that false-flagged optional chaining and `throw` inside any `try`. The `/react-compiler` subpath now exposes `rules` instead of `restrictedSyntaxGroups`.
- All selector-based hardening (`appGuardrails`, `reanimated`, `worklets`, `semanticColors`) composes into a single `no-restricted-syntax` config per file group, so stacking layers no longer clobbers selectors. The base `SafeAreaView` restriction is shared between the default app rules and `nativeUi`.

TypeScript:

- Export importable option types (`CreateConfigOptions` and every layer's option type) via namespace merge for accurate IDE/AI autocomplete and misuse detection.
- Fix invalid subpath declarations that mixed `export type` with `export =`.
- Add a scoped `typecheck` script (`tsc -p tsconfig.types.json`) plus type-surface tests, wired into CI.

Docs & release:

- Add consumer-facing `CHANGELOG.md`; sync `README.md` (new exports, hardening options, restricted-rule composition notes, changelog link) and `RULES.md`.
- Extend the packed-consumer smoke and config/release-notes reports to cover the new layers.
- Bump package version to `2.7.0`.
