### PR TITLE
fix: publish file globs for v2.7.0

### DIFF
--- a/packages/eslint-config-expo-magic/package.json
+++ b/packages/eslint-config-expo-magic/package.json
@@ -176,7 +176,9 @@
 		"worklets.d.ts",
 		"README.md",
 		"bin/*.js",
-		"utils/**/*.js",
+		"utils/*.js",
+		"utils/plugin/*.js",
+		"utils/plugin/rules/*.js",
 		".prettierrc.js"
 	],
 	"scripts": {


### PR DESCRIPTION
# Changes

- Replace the `utils/**/*.js` entry in the package `files` allowlist with explicit per-directory globs (`utils/*.js`, `utils/plugin/*.js`, `utils/plugin/rules/*.js`). The release publish validator (`scripts/publish-package.js`) only resolves single-level globs, so the recursive `**` form was reported as missing and aborted the npm publish for `v2.7.0`. The new globs publish the same files (including the bundled `expo-magic` plugin) and pass the publish validator, dry-run, and packed-consumer smoke across all SDK lanes.
